### PR TITLE
[Database] Add transactions to bulk database processes

### DIFF
--- a/app/src/main/kotlin/com/andreolas/movierama/ui/MovieApp.kt
+++ b/app/src/main/kotlin/com/andreolas/movierama/ui/MovieApp.kt
@@ -93,6 +93,10 @@ fun MovieApp(
                     restoreState = true
                   },
                 )
+                navigator.popBackStack(
+                  route = destination.direction,
+                  inclusive = false,
+                )
               },
               label = {
                 Text(text = stringResource(id = destination.titleTextId))

--- a/app/src/test/kotlin/com/andreolas/movierama/search/domain/repository/ProdDetailsRepositoryTest.kt
+++ b/app/src/test/kotlin/com/andreolas/movierama/search/domain/repository/ProdDetailsRepositoryTest.kt
@@ -43,7 +43,6 @@ import com.divinelink.core.testing.service.TestMediaService
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
-import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.Json
 import org.junit.Before
@@ -146,7 +145,6 @@ class ProdDetailsRepositoryTest {
       mediaRemote = mediaRemote.mock,
       creditsDao = creditsDao.mock,
       dispatcher = testDispatcher,
-      scope = TestScope(),
     )
   }
 
@@ -470,7 +468,6 @@ class ProdDetailsRepositoryTest {
       mediaRemote = mediaRemote.mock,
       creditsDao = defaultCreditDao,
       dispatcher = testDispatcher,
-      scope = TestScope(),
     )
 
     mediaRemote.mockFetchAggregateCredits(response = flowOf(creditsResponseApi))

--- a/core/data/src/test/kotlin/com/divinelink/core/data/details/person/ProdPersonRepositoryTest.kt
+++ b/core/data/src/test/kotlin/com/divinelink/core/data/details/person/ProdPersonRepositoryTest.kt
@@ -100,7 +100,6 @@ class ProdPersonRepositoryTest {
         val first = awaitItem().getOrNull()
         assertThat(first?.cast?.size).isEqualTo(124)
         assertThat(first?.crew?.size).isEqualTo(17)
-        awaitItem()
         expectNoEvents()
       }
     }

--- a/core/database/src/main/kotlin/com/divinelink/core/database/credits/dao/ProdCreditsDao.kt
+++ b/core/database/src/main/kotlin/com/divinelink/core/database/credits/dao/ProdCreditsDao.kt
@@ -57,8 +57,10 @@ class ProdCreditsDao @Inject constructor(
       )
   }
 
-  override fun insertCast(cast: List<SeriesCast>) = cast.forEach { castMember ->
-    database.seriesCastQueries.insertSeriesCast(castMember)
+  override fun insertCast(cast: List<SeriesCast>) = database.transaction {
+    cast.forEach { castMember ->
+      database.seriesCastQueries.insertSeriesCast(castMember)
+    }
   }
 
   override fun fetchAllCredits(id: Long): Flow<AggregateCreditsEntity> {
@@ -74,8 +76,10 @@ class ProdCreditsDao @Inject constructor(
     }
   }
 
-  override fun insertCastRoles(roles: List<SeriesCastRole>) = roles.forEach { role ->
-    database.seriesCastRoleQueries.insertRole(seriesCastRole = role)
+  override fun insertCastRoles(roles: List<SeriesCastRole>) = database.transaction {
+    roles.forEach { role ->
+      database.seriesCastRoleQueries.insertRole(seriesCastRole = role)
+    }
   }
 
   override fun fetchAllCastWithRoles(id: Long): Flow<List<CastEntity>> = database
@@ -87,12 +91,16 @@ class ProdCreditsDao @Inject constructor(
       listOfCast.map(SeriesCastWithRole::toEntity)
     }
 
-  override fun insertCrew(crew: List<SeriesCrew>) = crew.forEach { crewMember ->
-    database.seriesCrewQueries.insertCrew(crewMember)
+  override fun insertCrew(crew: List<SeriesCrew>) = database.transaction {
+    crew.forEach { crewMember ->
+      database.seriesCrewQueries.insertCrew(crewMember)
+    }
   }
 
-  override fun insertCrewJobs(jobs: List<SeriesCrewJob>) = jobs.forEach { job ->
-    database.seriesCrewJobQueries.insertCrewJob(seriesCrewJob = job)
+  override fun insertCrewJobs(jobs: List<SeriesCrewJob>) = database.transaction {
+    jobs.forEach { job ->
+      database.seriesCrewJobQueries.insertCrewJob(seriesCrewJob = job)
+    }
   }
 
   override fun fetchAllCrewJobs(aggregateCreditId: Long): Flow<List<CrewEntity>> = database

--- a/core/database/src/main/kotlin/com/divinelink/core/database/person/ProdPersonDao.kt
+++ b/core/database/src/main/kotlin/com/divinelink/core/database/person/ProdPersonDao.kt
@@ -44,12 +44,16 @@ class ProdPersonDao @Inject constructor(
       )
   }
 
-  override fun insertPersonCastCredits(cast: List<PersonCastCreditEntity>) = cast.forEach {
-    database.personCastCreditEntityQueries.insertPersonCastCredit(it)
+  override fun insertPersonCastCredits(cast: List<PersonCastCreditEntity>) = database.transaction {
+    cast.forEach {
+      database.personCastCreditEntityQueries.insertPersonCastCredit(it)
+    }
   }
 
-  override fun insertPersonCrewCredits(crew: List<PersonCrewCreditEntity>) = crew.forEach {
-    database.personCrewCreditEntityQueries.insertPersonCrewCredit(it)
+  override fun insertPersonCrewCredits(crew: List<PersonCrewCreditEntity>) = database.transaction {
+    crew.forEach {
+      database.personCrewCreditEntityQueries.insertPersonCrewCredit(it)
+    }
   }
 
   override fun fetchPersonCombinedCredits(id: Long): Flow<PersonCombinedCreditsEntity?> {

--- a/core/database/src/main/sqldelight/com/divinelink/core/database/credits/AggregateCredits.sq
+++ b/core/database/src/main/sqldelight/com/divinelink/core/database/credits/AggregateCredits.sq
@@ -7,5 +7,5 @@ checkIfExistAndNotExpired:
 SELECT EXISTS(SELECT 1 FROM aggregateCredits WHERE id = ? AND expiresAtEpochSeconds > ?);
 
 insert:
-INSERT INTO aggregateCredits (id, expiresAtEpochSeconds)
+INSERT OR REPLACE INTO aggregateCredits (id, expiresAtEpochSeconds)
 VALUES ?;

--- a/core/database/src/main/sqldelight/com/divinelink/core/database/credits/cast/SeriesCast.sq
+++ b/core/database/src/main/sqldelight/com/divinelink/core/database/credits/cast/SeriesCast.sq
@@ -11,7 +11,7 @@ CREATE TABLE seriesCast(
 );
 
 insertSeriesCast:
-INSERT INTO seriesCast(
+INSERT OR REPLACE INTO seriesCast(
   id,
   name,
   originalName,

--- a/core/database/src/main/sqldelight/com/divinelink/core/database/credits/cast/SeriesCastRole.sq
+++ b/core/database/src/main/sqldelight/com/divinelink/core/database/credits/cast/SeriesCastRole.sq
@@ -8,5 +8,5 @@ CREATE TABLE seriesCastRole(
 );
 
 insertRole:
-INSERT INTO seriesCastRole(creditId, character, episodeCount, castId, aggregateCreditId)
+INSERT OR REPLACE INTO seriesCastRole(creditId, character, episodeCount, castId, aggregateCreditId)
 VALUES ?;

--- a/core/database/src/main/sqldelight/com/divinelink/core/database/credits/crew/SeriesCrew.sq
+++ b/core/database/src/main/sqldelight/com/divinelink/core/database/credits/crew/SeriesCrew.sq
@@ -13,7 +13,7 @@ CREATE TABLE seriesCrew (
 );
 
 insertCrew:
-INSERT INTO seriesCrew(
+INSERT OR REPLACE INTO seriesCrew(
   id,
   name,
   originalName,

--- a/core/database/src/main/sqldelight/com/divinelink/core/database/credits/crew/SeriesCrewJob.sq
+++ b/core/database/src/main/sqldelight/com/divinelink/core/database/credits/crew/SeriesCrewJob.sq
@@ -8,5 +8,5 @@ CREATE TABLE seriesCrewJob(
 );
 
 insertCrewJob:
-INSERT INTO seriesCrewJob(creditId, job, episodeCount, crewId, aggregateCreditId)
+INSERT OR REPLACE INTO seriesCrewJob(creditId, job, episodeCount, crewId, aggregateCreditId)
 VALUES ?;

--- a/docs/RootNavGraph.html
+++ b/docs/RootNavGraph.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Watchlist/root Navigation Graph</title>
+</head>
+<body>
+<pre id='scene' class="mermaid">
+---
+title: Watchlist/root Navigation Graph
+---
+%%{init: {'theme':'base', 'themeVariables': { 'primaryTextColor': '#fff' }}%%
+graph TD
+watchlist/root(["RootGraph"]) -- "start" --- watchlist/watchlist(["WatchlistGraph"])
+watchlist/watchlist(["WatchlistGraph"]) -- "start" --- watchlist/watchlist_screen("WatchlistScreen")
+
+
+classDef destination fill:#5383EC,stroke:#ffffff;
+class watchlist/watchlist_screen destination;
+classDef navgraph fill:#63BC76,stroke:#ffffff;
+class watchlist/watchlist,watchlist/root,watchlist/watchlist navgraph;
+
+</pre>
+<script src='https://unpkg.com/panzoom@9.4.0/dist/panzoom.min.js'></script>
+<script type="module">import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.esm.min.mjs';</script>
+<script>
+var element = document.getElementById('scene')
+var pz = panzoom(element, {
+  minZoom: 0.5
+});
+
+function reset(e) {
+   pz.moveTo(0, 0); 
+   pz.zoomAbs(0, 0, 1);
+}
+
+function zoomIn(e) {
+   pz.smoothZoom(0, 0, 1.25);
+}
+
+function zoomOut(e) {
+   pz.smoothZoom(0, 0, 0.75);
+}
+
+document.addEventListener('keydown', function(event) {
+    const keycode = event.keyCode;
+    const key = event.key;
+    
+    switch(keycode) {
+        case 82: // R key
+            reset(event);
+            break;
+        case 187: // + key
+            zoomIn(event);
+            break;
+        case 189: // - key
+            zoomOut(event);
+            break;
+    }
+});
+</script>
+</body>
+</html>

--- a/docs/RootNavGraph.mmd
+++ b/docs/RootNavGraph.mmd
@@ -1,0 +1,13 @@
+---
+title: Watchlist/root Navigation Graph
+---
+%%{init: {'theme':'base', 'themeVariables': { 'primaryTextColor': '#fff' }}%%
+graph TD
+watchlist/root(["RootGraph"]) -- "start" --- watchlist/watchlist(["WatchlistGraph"])
+watchlist/watchlist(["WatchlistGraph"]) -- "start" --- watchlist/watchlist_screen("WatchlistScreen")
+
+
+classDef destination fill:#5383EC,stroke:#ffffff;
+class watchlist/watchlist_screen destination;
+classDef navgraph fill:#63BC76,stroke:#ffffff;
+class watchlist/watchlist,watchlist/root,watchlist/watchlist navgraph;


### PR DESCRIPTION
In this pull request, we added transactions to the database bulk processes to improve their performance. This change allows for the immediate insertion of TV cast and crew data, compared to the previous approach where the insertions took longer to complete. 

Additionally, we updated the navigation behavior of the bottom navigation buttons. Previously, if a top-level destination (currently Home and Watchlist) was already on the backstack, clicking it wouldn't navigate to that destination. For example, if you were on the Home screen, navigated to Movie Details, and then clicked Home again, nothing would happen. Now, clicking a top-level destination clears the entire backstack and navigates directly to the selected destination. This makes it much easier to return to top-level destinations, eliminating the need to manually navigate back through the stack.