### PR TITLE
[Jellyseerr] Introduce ReAuth interceptor on Jellyseerr Ktor Client

### DIFF
--- a/app/src/test/kotlin/com/andreolas/movierama/details/ui/DetailsViewModelRobot.kt
+++ b/app/src/test/kotlin/com/andreolas/movierama/details/ui/DetailsViewModelRobot.kt
@@ -7,6 +7,7 @@ import com.andreolas.movierama.fakes.usecase.FakeMarkAsFavoriteUseCase
 import com.andreolas.movierama.fakes.usecase.details.FakeAddToWatchlistUseCase
 import com.andreolas.movierama.fakes.usecase.details.FakeDeleteRatingUseCase
 import com.andreolas.movierama.fakes.usecase.details.FakeSubmitRatingUseCase
+import com.divinelink.core.model.jellyseerr.request.JellyseerrMediaRequest
 import com.divinelink.core.model.media.MediaItem
 import com.divinelink.core.model.media.MediaType
 import com.divinelink.core.testing.MainDispatcherRule
@@ -65,6 +66,10 @@ class DetailsViewModelRobot {
     )
   }
 
+  fun mockRequestMedia(response: Flow<Result<JellyseerrMediaRequest>>) = apply {
+    fakeRequestMediaUseCase.mockSuccess(response = response)
+  }
+
   fun onAddRateClicked() = apply {
     viewModel.onAddRateClicked()
   }
@@ -91,6 +96,10 @@ class DetailsViewModelRobot {
 
   fun onMarkAsFavorite() = apply {
     viewModel.onMarkAsFavorite()
+  }
+
+  fun onRequestMedia(seasons: List<Int>) = apply {
+    viewModel.onRequestMedia(seasons)
   }
 
   fun consumeSnackbar() = apply {

--- a/app/src/test/kotlin/com/andreolas/movierama/session/SessionStorageTest.kt
+++ b/app/src/test/kotlin/com/andreolas/movierama/session/SessionStorageTest.kt
@@ -137,6 +137,7 @@ class SessionStorageTest {
     )
     val encryptedPreferenceStorage = FakeEncryptedPreferenceStorage(
       jellyseerrAuthCookie = "123456789qwertyuiop",
+      jellyseerrPassword = "password",
     )
 
     val sessionStorage = SessionStorage(
@@ -157,5 +158,6 @@ class SessionStorageTest {
     assertThat(preferenceStorage.jellyseerrAddress.first()).isNull()
     assertThat(preferenceStorage.jellyseerrSignInMethod.first()).isNull()
     assertThat(encryptedPreferenceStorage.jellyseerrAuthCookie).isNull()
+    assertThat(encryptedPreferenceStorage.jellyseerrPassword).isNull()
   }
 }

--- a/core/data/src/main/kotlin/com/divinelink/core/data/jellyseerr/repository/ProdJellyseerrRepository.kt
+++ b/core/data/src/main/kotlin/com/divinelink/core/data/jellyseerr/repository/ProdJellyseerrRepository.kt
@@ -4,6 +4,7 @@ import app.cash.sqldelight.coroutines.asFlow
 import app.cash.sqldelight.coroutines.mapToOneOrNull
 import com.divinelink.core.commons.domain.DispatcherProvider
 import com.divinelink.core.data.jellyseerr.mapper.map
+import com.divinelink.core.database.JellyseerrAccountDetailsQueries
 import com.divinelink.core.database.jellyseerr.mapper.map
 import com.divinelink.core.database.jellyseerr.mapper.mapToEntity
 import com.divinelink.core.model.jellyseerr.JellyseerrAccountDetails
@@ -12,9 +13,7 @@ import com.divinelink.core.model.jellyseerr.request.JellyseerrMediaRequest
 import com.divinelink.core.network.jellyseerr.model.JellyseerrRequestMediaBodyApi
 import com.divinelink.core.network.jellyseerr.model.map
 import com.divinelink.core.network.jellyseerr.service.JellyseerrService
-import com.divinelink.core.database.JellyseerrAccountDetailsQueries
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.map
 
 class ProdJellyseerrRepository(
@@ -27,23 +26,13 @@ class ProdJellyseerrRepository(
     loginData: JellyseerrLoginData,
   ): Flow<Result<JellyseerrAccountDetails>> = service
     .signInWithJellyfin(loginData)
-    .map {
-      Result.success(it.map())
-    }
-    .catch { error ->
-      throw error
-    }
+    .map { Result.success(it.map()) }
 
   override suspend fun signInWithJellyseerr(
     loginData: JellyseerrLoginData,
   ): Flow<Result<JellyseerrAccountDetails>> = service
     .signInWithJellyseerr(loginData)
-    .map {
-      Result.success(it.map())
-    }
-    .catch { error ->
-      throw error
-    }
+    .map { Result.success(it.map()) }
 
   override fun getJellyseerrAccountDetails(): Flow<JellyseerrAccountDetails?> = queries
     .selectAll()
@@ -62,21 +51,11 @@ class ProdJellyseerrRepository(
   }
 
   override suspend fun logout(address: String): Flow<Result<Unit>> = service.logout(address)
-    .map {
-      Result.success(Unit)
-    }
-    .catch { error ->
-      throw error
-    }
+    .map { Result.success(Unit) }
 
   override suspend fun requestMedia(
     body: JellyseerrRequestMediaBodyApi,
   ): Flow<Result<JellyseerrMediaRequest>> = service
     .requestMedia(body)
-    .map {
-      Result.success(it.map())
-    }
-    .catch { error ->
-      throw error
-    }
+    .map { Result.success(it.map()) }
 }

--- a/core/datastore/src/main/java/com/divinelink/core/datastore/EncryptedPreferenceStorage.kt
+++ b/core/datastore/src/main/java/com/divinelink/core/datastore/EncryptedPreferenceStorage.kt
@@ -19,11 +19,15 @@ interface EncryptedStorage {
   suspend fun clearJellyseerrAuthCookie()
   suspend fun setJellyseerrAuthCookie(cookie: String)
   val jellyseerrAuthCookie: String?
+
+  suspend fun clearJellyseerrPassword()
+  suspend fun setJellyseerrPassword(password: String)
+  val jellyseerrPassword: String?
 }
 
 class EncryptedPreferenceStorage(
   private val preferenceStorage: PreferenceStorage,
-  val context: Context,
+  context: Context,
 ) : EncryptedStorage {
 
   private var masterKey: MasterKey = MasterKey
@@ -44,6 +48,7 @@ class EncryptedPreferenceStorage(
     const val SECRET_TMDB_AUTH_TOKEN = "secret.tmdb.auth.token"
     const val SECRET_TMDB_SESSION_ID = "secret.tmdb.token.id"
     const val SECRET_JELLYSEERR_AUTH_COOKIE = "secret.jellyseerr.auth.cookie"
+    const val SECRET_JELLYSEERR_PASSWORD = "secret.jellyseerr.password"
   }
 
   override suspend fun setTmdbAuthToken(key: String) {
@@ -89,6 +94,23 @@ class EncryptedPreferenceStorage(
 
   override val jellyseerrAuthCookie: String?
     get() = encryptedPreferences.getString(PreferencesKeys.SECRET_JELLYSEERR_AUTH_COOKIE, null)
+
+  override suspend fun clearJellyseerrPassword() {
+    with(encryptedPreferences.edit()) {
+      remove(PreferencesKeys.SECRET_JELLYSEERR_PASSWORD)
+      apply()
+    }
+  }
+
+  override suspend fun setJellyseerrPassword(password: String) {
+    with(encryptedPreferences.edit()) {
+      putString(PreferencesKeys.SECRET_JELLYSEERR_PASSWORD, password)
+      apply()
+    }
+  }
+
+  override val jellyseerrPassword: String?
+    get() = encryptedPreferences.getString(PreferencesKeys.SECRET_JELLYSEERR_PASSWORD, null)
 
   /**
    * Known issue: https://issuetracker.google.com/issues/158234058

--- a/core/datastore/src/main/java/com/divinelink/core/datastore/SessionStorage.kt
+++ b/core/datastore/src/main/java/com/divinelink/core/datastore/SessionStorage.kt
@@ -40,6 +40,7 @@ class SessionStorage(
   }
 
   suspend fun clearJellyseerrSession() {
+    encryptedStorage.clearJellyseerrPassword()
     encryptedStorage.clearJellyseerrAuthCookie()
     storage.clearJellyseerrAccount()
     storage.clearJellyseerrSignInMethod()

--- a/core/domain/src/main/kotlin/com/divinelink/core/domain/jellyseerr/LoginJellyseerrUseCase.kt
+++ b/core/domain/src/main/kotlin/com/divinelink/core/domain/jellyseerr/LoginJellyseerrUseCase.kt
@@ -1,12 +1,13 @@
 package com.divinelink.core.domain.jellyseerr
 
+import com.divinelink.core.commons.domain.DispatcherProvider
 import com.divinelink.core.commons.domain.FlowUseCase
 import com.divinelink.core.data.jellyseerr.repository.JellyseerrRepository
+import com.divinelink.core.datastore.EncryptedStorage
 import com.divinelink.core.datastore.PreferenceStorage
 import com.divinelink.core.model.jellyseerr.JellyseerrAccountDetails
 import com.divinelink.core.model.jellyseerr.JellyseerrLoginMethod
 import com.divinelink.core.model.jellyseerr.JellyseerrLoginParams
-import com.divinelink.core.commons.domain.DispatcherProvider
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.last
@@ -14,6 +15,7 @@ import kotlinx.coroutines.flow.last
 open class LoginJellyseerrUseCase(
   private val repository: JellyseerrRepository,
   private val storage: PreferenceStorage,
+  private val encryptedStorage: EncryptedStorage,
   val dispatcher: DispatcherProvider,
 ) : FlowUseCase<JellyseerrLoginParams?, JellyseerrAccountDetails>(dispatcher.io) {
 
@@ -38,6 +40,7 @@ open class LoginJellyseerrUseCase(
           storage.setJellyseerrAccount(parameters.username.value)
           storage.setJellyseerrAddress(parameters.address)
           storage.setJellyseerrSignInMethod(parameters.signInMethod.name)
+          encryptedStorage.setJellyseerrPassword(parameters.password.value)
           repository.insertJellyseerrAccountDetails(accountDetails)
 
           emit(Result.success(accountDetails))

--- a/core/domain/src/main/kotlin/com/divinelink/core/domain/jellyseerr/LogoutJellyseerrUseCase.kt
+++ b/core/domain/src/main/kotlin/com/divinelink/core/domain/jellyseerr/LogoutJellyseerrUseCase.kt
@@ -1,13 +1,14 @@
 package com.divinelink.core.domain.jellyseerr
 
+import com.divinelink.core.commons.domain.DispatcherProvider
 import com.divinelink.core.commons.domain.FlowUseCase
 import com.divinelink.core.data.jellyseerr.repository.JellyseerrRepository
 import com.divinelink.core.datastore.SessionStorage
-import com.divinelink.core.commons.domain.DispatcherProvider
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.last
+import kotlinx.coroutines.flow.onCompletion
 
 open class LogoutJellyseerrUseCase(
   private val repository: JellyseerrRepository,
@@ -23,16 +24,17 @@ open class LogoutJellyseerrUseCase(
     }
 
     emit(
-      repository.logout(address).last().fold(
-        onSuccess = {
+      repository
+        .logout(address)
+        .onCompletion {
           sessionStorage.clearJellyseerrSession()
           repository.clearJellyseerrAccountDetails()
-          Result.success(address)
-        },
-        onFailure = {
-          Result.failure(it)
-        },
-      ),
+        }
+        .last()
+        .fold(
+          onSuccess = { Result.success(address) },
+          onFailure = { Result.failure(it) },
+        ),
     )
   }
 }

--- a/core/domain/src/test/kotlin/com/divinelink/core/domain/jellyseerr/LoginJellyseerrUseCaseTest.kt
+++ b/core/domain/src/test/kotlin/com/divinelink/core/domain/jellyseerr/LoginJellyseerrUseCaseTest.kt
@@ -60,6 +60,8 @@ class LoginJellyseerrUseCaseTest {
       encryptedStorage = encryptedStorage,
     )
 
+    assertThat(encryptedStorage.jellyseerrPassword).isNull()
+
     useCase.invoke(
       JellyseerrLoginParams(
         username = Username("jellyfinUsername"),
@@ -75,6 +77,7 @@ class LoginJellyseerrUseCaseTest {
       assertThat(
         preferenceStorage.jellyseerrSignInMethod.first(),
       ).isEqualTo(JellyseerrLoginMethod.JELLYFIN.name)
+      assertThat(encryptedStorage.jellyseerrPassword).isEqualTo("password")
     }
   }
 
@@ -94,6 +97,8 @@ class LoginJellyseerrUseCaseTest {
       encryptedStorage = encryptedStorage,
     )
 
+    assertThat(encryptedStorage.jellyseerrPassword).isNull()
+
     useCase.invoke(
       JellyseerrLoginParams(
         username = Username("jellyseerrUsername"),
@@ -109,6 +114,7 @@ class LoginJellyseerrUseCaseTest {
       assertThat(
         preferenceStorage.jellyseerrSignInMethod.first(),
       ).isEqualTo(JellyseerrLoginMethod.JELLYSEERR.name)
+      assertThat(encryptedStorage.jellyseerrPassword).isEqualTo("password")
     }
   }
 

--- a/core/domain/src/test/kotlin/com/divinelink/core/domain/jellyseerr/LoginJellyseerrUseCaseTest.kt
+++ b/core/domain/src/test/kotlin/com/divinelink/core/domain/jellyseerr/LoginJellyseerrUseCaseTest.kt
@@ -1,5 +1,6 @@
 package com.divinelink.core.domain.jellyseerr
 
+import com.divinelink.core.datastore.EncryptedStorage
 import com.divinelink.core.datastore.PreferenceStorage
 import com.divinelink.core.model.Password
 import com.divinelink.core.model.Username
@@ -8,6 +9,7 @@ import com.divinelink.core.model.jellyseerr.JellyseerrLoginParams
 import com.divinelink.core.testing.MainDispatcherRule
 import com.divinelink.core.testing.factories.model.jellyseerr.JellyseerrAccountDetailsFactory
 import com.divinelink.core.testing.repository.TestJellyseerrRepository
+import com.divinelink.core.testing.storage.FakeEncryptedPreferenceStorage
 import com.divinelink.core.testing.storage.FakePreferenceStorage
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.flow.first
@@ -18,6 +20,7 @@ import kotlin.test.Test
 class LoginJellyseerrUseCaseTest {
 
   private lateinit var preferenceStorage: PreferenceStorage
+  private lateinit var encryptedStorage: EncryptedStorage
 
   private val repository = TestJellyseerrRepository()
 
@@ -28,11 +31,13 @@ class LoginJellyseerrUseCaseTest {
   @Test
   fun `test loginJellyseerr with null parameters throws exception`() = runTest {
     preferenceStorage = FakePreferenceStorage()
+    encryptedStorage = FakeEncryptedPreferenceStorage()
 
     val useCase = LoginJellyseerrUseCase(
       repository = repository.mock,
       storage = preferenceStorage,
       dispatcher = testDispatcher,
+      encryptedStorage = encryptedStorage,
     )
 
     useCase.invoke(null).collect {
@@ -44,6 +49,7 @@ class LoginJellyseerrUseCaseTest {
   @Test
   fun `test loginJellyseerr with Jellyfin login method`() = runTest {
     preferenceStorage = FakePreferenceStorage()
+    encryptedStorage = FakeEncryptedPreferenceStorage()
 
     repository.mockSignInWithJellyfin(Result.success(JellyseerrAccountDetailsFactory.jellyfin()))
 
@@ -51,6 +57,7 @@ class LoginJellyseerrUseCaseTest {
       repository = repository.mock,
       storage = preferenceStorage,
       dispatcher = testDispatcher,
+      encryptedStorage = encryptedStorage,
     )
 
     useCase.invoke(
@@ -74,6 +81,7 @@ class LoginJellyseerrUseCaseTest {
   @Test
   fun `test loginJellyseerr with Jellyseerr login method`() = runTest {
     preferenceStorage = FakePreferenceStorage()
+    encryptedStorage = FakeEncryptedPreferenceStorage()
 
     repository.mockSignInWithJellyseerr(
       Result.success(JellyseerrAccountDetailsFactory.jellyseerr()),
@@ -83,6 +91,7 @@ class LoginJellyseerrUseCaseTest {
       repository = repository.mock,
       storage = preferenceStorage,
       dispatcher = testDispatcher,
+      encryptedStorage = encryptedStorage,
     )
 
     useCase.invoke(
@@ -106,6 +115,7 @@ class LoginJellyseerrUseCaseTest {
   @Test
   fun `test loginJellyseerr with Jellyseerr login method and error`() = runTest {
     preferenceStorage = FakePreferenceStorage()
+    encryptedStorage = FakeEncryptedPreferenceStorage()
 
     repository.mockSignInWithJellyseerr(Result.failure(Exception("error")))
 
@@ -113,6 +123,7 @@ class LoginJellyseerrUseCaseTest {
       repository = repository.mock,
       storage = preferenceStorage,
       dispatcher = testDispatcher,
+      encryptedStorage = encryptedStorage,
     )
 
     useCase.invoke(
@@ -130,6 +141,7 @@ class LoginJellyseerrUseCaseTest {
   @Test
   fun `test loginJellyseerr with Jellyfin login method and error`() = runTest {
     preferenceStorage = FakePreferenceStorage()
+    encryptedStorage = FakeEncryptedPreferenceStorage()
 
     repository.mockSignInWithJellyfin(Result.failure(Exception("error")))
 
@@ -137,6 +149,7 @@ class LoginJellyseerrUseCaseTest {
       repository = repository.mock,
       storage = preferenceStorage,
       dispatcher = testDispatcher,
+      encryptedStorage = encryptedStorage,
     )
 
     useCase.invoke(

--- a/core/model/src/main/kotlin/com/divinelink/core/model/exception/JellyseerrUnauthorizedException.kt
+++ b/core/model/src/main/kotlin/com/divinelink/core/model/exception/JellyseerrUnauthorizedException.kt
@@ -1,0 +1,3 @@
+package com.divinelink.core.model.exception
+
+class JellyseerrUnauthorizedException : Exception()

--- a/core/model/src/main/kotlin/com/divinelink/core/model/exception/JellyseerrUnauthorizedException.kt
+++ b/core/model/src/main/kotlin/com/divinelink/core/model/exception/JellyseerrUnauthorizedException.kt
@@ -1,3 +1,5 @@
 package com.divinelink.core.model.exception
 
 class JellyseerrUnauthorizedException : Exception()
+
+class JellyseerrInvalidCredentials : Exception()

--- a/core/model/src/main/kotlin/com/divinelink/core/model/jellyseerr/JellyseerrLoginMethod.kt
+++ b/core/model/src/main/kotlin/com/divinelink/core/model/jellyseerr/JellyseerrLoginMethod.kt
@@ -1,6 +1,12 @@
+@file:Suppress("ktlint:standard:trailing-comma-on-declaration-site")
+
 package com.divinelink.core.model.jellyseerr
 
-enum class JellyseerrLoginMethod {
-  JELLYFIN,
-  JELLYSEERR,
+enum class JellyseerrLoginMethod(val endpoint: String) {
+  JELLYFIN("jellyfin"),
+  JELLYSEERR("local");
+
+  companion object {
+    fun from(name: String): JellyseerrLoginMethod? = entries.find { it.name == name }
+  }
 }

--- a/core/network/src/main/kotlin/com/divinelink/core/network/client/JellyseerrRestClient.kt
+++ b/core/network/src/main/kotlin/com/divinelink/core/network/client/JellyseerrRestClient.kt
@@ -1,19 +1,77 @@
 package com.divinelink.core.network.client
 
 import com.divinelink.core.datastore.EncryptedStorage
+import com.divinelink.core.datastore.PreferenceStorage
+import com.divinelink.core.model.exception.JellyseerrUnauthorizedException
+import com.divinelink.core.model.jellyseerr.JellyseerrLoginMethod
+import com.divinelink.core.network.jellyseerr.model.JellyfinLoginResponseApi
+import com.divinelink.core.network.jellyseerr.model.JellyseerrLoginRequestBodyApi
+import com.divinelink.core.network.jellyseerr.model.toRequestBodyApi
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.HttpClientEngine
+import io.ktor.client.plugins.HttpRequestRetry
+import io.ktor.client.plugins.HttpResponseValidator
 import io.ktor.client.plugins.cookies.HttpCookies
+import io.ktor.client.statement.HttpReceivePipeline
+import io.ktor.http.HttpStatusCode
+import kotlinx.coroutines.flow.first
 
 class JellyseerrRestClient(
   engine: HttpClientEngine,
   private val encryptedStorage: EncryptedStorage,
+  private val datastore: PreferenceStorage,
 ) {
 
-  val client: HttpClient = ktorClient(engine).config {
-    install(HttpCookies) {
-      storage = PersistentCookieStorage(encryptedStorage)
+  val client: HttpClient = ktorClient(engine)
+    .config {
+      install(HttpCookies) {
+        storage = PersistentCookieStorage(encryptedStorage)
+      }
+
+      HttpResponseValidator {
+        validateResponse { response ->
+          if (response.status == HttpStatusCode.Unauthorized) {
+            throw JellyseerrUnauthorizedException()
+          }
+        }
+      }
+
+      install(HttpRequestRetry) {
+        retryIf(maxRetries = 1) { _, response ->
+          when {
+            response.status != HttpStatusCode.Unauthorized -> false
+            else -> true
+          }
+        }
+      }
     }
+    .apply {
+      receivePipeline.intercept(HttpReceivePipeline.Before) {
+        if (subject.status == HttpStatusCode.Unauthorized) {
+          reAuthenticate()
+        }
+      }
+    }
+
+  private suspend fun reAuthenticate() {
+    val account = datastore.jellyseerrAccount.first()
+    val password = encryptedStorage.jellyseerrPassword
+    val address = datastore.jellyseerrAddress.first()
+    val signInMethod = datastore.jellyseerrSignInMethod.first()
+
+    if (account == null || password == null || address == null || signInMethod == null) {
+      throw JellyseerrUnauthorizedException()
+    }
+
+    val loginMethod = JellyseerrLoginMethod.from(signInMethod)
+      ?: throw JellyseerrUnauthorizedException()
+
+    val body = loginMethod.toRequestBodyApi(account, password)
+
+    post<JellyseerrLoginRequestBodyApi, JellyfinLoginResponseApi>(
+      url = "$address/api/v1/auth/${loginMethod.endpoint}",
+      body = body,
+    )
   }
 
   suspend inline fun <reified T : Any> get(url: String): T = client.get(url)

--- a/core/network/src/main/kotlin/com/divinelink/core/network/client/PersistentCookieStorage.kt
+++ b/core/network/src/main/kotlin/com/divinelink/core/network/client/PersistentCookieStorage.kt
@@ -10,7 +10,6 @@ import io.ktor.util.date.GMTDate
 /**
  * A [CookiesStorage] implementation that stores cookies in an encrypted storage.
  */
-
 class PersistentCookieStorage(val storage: EncryptedStorage) : CookiesStorage {
   override suspend fun get(requestUrl: Url): List<Cookie> {
     val cookies = mutableListOf<Cookie>()
@@ -18,8 +17,7 @@ class PersistentCookieStorage(val storage: EncryptedStorage) : CookiesStorage {
     val storedCookie = storage.jellyseerrAuthCookie ?: return cookies
 
     val cookie = stringToCookie(storedCookie)
-    // TODO handle expired cookie - cookie.isExpired()
-    if (cookie != null) {
+    if (cookie != null && !cookie.isExpired()) {
       cookies.add(cookie)
     }
     return cookies

--- a/core/network/src/main/kotlin/com/divinelink/core/network/client/PersistentCookieStorage.kt
+++ b/core/network/src/main/kotlin/com/divinelink/core/network/client/PersistentCookieStorage.kt
@@ -18,7 +18,8 @@ class PersistentCookieStorage(val storage: EncryptedStorage) : CookiesStorage {
     val storedCookie = storage.jellyseerrAuthCookie ?: return cookies
 
     val cookie = stringToCookie(storedCookie)
-    if (cookie != null && !cookie.isExpired()) {
+    // TODO handle expired cookie - cookie.isExpired()
+    if (cookie != null) {
       cookies.add(cookie)
     }
     return cookies

--- a/core/network/src/main/kotlin/com/divinelink/core/network/jellyseerr/model/JellyfinLoginRequestBodyApi.kt
+++ b/core/network/src/main/kotlin/com/divinelink/core/network/jellyseerr/model/JellyfinLoginRequestBodyApi.kt
@@ -1,9 +1,0 @@
-package com.divinelink.core.network.jellyseerr.model
-
-import kotlinx.serialization.Serializable
-
-@Serializable
-data class JellyfinLoginRequestBodyApi(
-  val username: String,
-  val password: String,
-)

--- a/core/network/src/main/kotlin/com/divinelink/core/network/jellyseerr/model/JellyseerrLoginRequestBodyApi.kt
+++ b/core/network/src/main/kotlin/com/divinelink/core/network/jellyseerr/model/JellyseerrLoginRequestBodyApi.kt
@@ -1,9 +1,32 @@
 package com.divinelink.core.network.jellyseerr.model
 
+import com.divinelink.core.model.jellyseerr.JellyseerrLoginMethod
 import kotlinx.serialization.Serializable
 
-@Serializable
-data class JellyseerrLoginRequestBodyApi(
-  val email: String,
-  val password: String,
-)
+sealed interface JellyseerrLoginRequestBodyApi {
+  @Serializable
+  data class Jellyfin(
+    val username: String,
+    val password: String,
+  ) : JellyseerrLoginRequestBodyApi
+
+  @Serializable
+  data class Jellyseerr(
+    val email: String,
+    val password: String,
+  ) : JellyseerrLoginRequestBodyApi
+}
+
+fun JellyseerrLoginMethod.toRequestBodyApi(
+  username: String,
+  password: String,
+): JellyseerrLoginRequestBodyApi = when (this) {
+  JellyseerrLoginMethod.JELLYFIN -> JellyseerrLoginRequestBodyApi.Jellyfin(
+    username = username,
+    password = password,
+  )
+  JellyseerrLoginMethod.JELLYSEERR -> JellyseerrLoginRequestBodyApi.Jellyseerr(
+    email = username,
+    password = password,
+  )
+}

--- a/core/network/src/main/kotlin/com/divinelink/core/network/jellyseerr/service/ProdJellyseerrService.kt
+++ b/core/network/src/main/kotlin/com/divinelink/core/network/jellyseerr/service/ProdJellyseerrService.kt
@@ -2,6 +2,7 @@ package com.divinelink.core.network.jellyseerr.service
 
 import com.divinelink.core.model.jellyseerr.JellyseerrLoginData
 import com.divinelink.core.network.client.JellyseerrRestClient
+import com.divinelink.core.network.client.JellyseerrRestClient.Companion.AUTH_ENDPOINT
 import com.divinelink.core.network.jellyseerr.model.JellyfinLoginResponseApi
 import com.divinelink.core.network.jellyseerr.model.JellyseerrLoginRequestBodyApi
 import com.divinelink.core.network.jellyseerr.model.JellyseerrRequestMediaBodyApi
@@ -14,7 +15,7 @@ class ProdJellyseerrService(private val restClient: JellyseerrRestClient) : Jell
   override suspend fun signInWithJellyfin(
     jellyfinLogin: JellyseerrLoginData,
   ): Flow<JellyfinLoginResponseApi> = flow {
-    val url = "${jellyfinLogin.address}/api/v1/auth/jellyfin"
+    val url = "${jellyfinLogin.address}${AUTH_ENDPOINT}jellyfin"
 
     val response = restClient.post<JellyseerrLoginRequestBodyApi, JellyfinLoginResponseApi>(
       url = url,
@@ -30,7 +31,7 @@ class ProdJellyseerrService(private val restClient: JellyseerrRestClient) : Jell
   override suspend fun signInWithJellyseerr(
     jellyseerrLogin: JellyseerrLoginData,
   ): Flow<JellyfinLoginResponseApi> = flow {
-    val url = "${jellyseerrLogin.address}/api/v1/auth/local"
+    val url = "${jellyseerrLogin.address}${AUTH_ENDPOINT}local"
 
     val response = restClient.post<JellyseerrLoginRequestBodyApi, JellyfinLoginResponseApi>(
       url = url,

--- a/core/network/src/main/kotlin/com/divinelink/core/network/jellyseerr/service/ProdJellyseerrService.kt
+++ b/core/network/src/main/kotlin/com/divinelink/core/network/jellyseerr/service/ProdJellyseerrService.kt
@@ -2,7 +2,6 @@ package com.divinelink.core.network.jellyseerr.service
 
 import com.divinelink.core.model.jellyseerr.JellyseerrLoginData
 import com.divinelink.core.network.client.JellyseerrRestClient
-import com.divinelink.core.network.jellyseerr.model.JellyfinLoginRequestBodyApi
 import com.divinelink.core.network.jellyseerr.model.JellyfinLoginResponseApi
 import com.divinelink.core.network.jellyseerr.model.JellyseerrLoginRequestBodyApi
 import com.divinelink.core.network.jellyseerr.model.JellyseerrRequestMediaBodyApi
@@ -17,9 +16,9 @@ class ProdJellyseerrService(private val restClient: JellyseerrRestClient) : Jell
   ): Flow<JellyfinLoginResponseApi> = flow {
     val url = "${jellyfinLogin.address}/api/v1/auth/jellyfin"
 
-    val response = restClient.post<JellyfinLoginRequestBodyApi, JellyfinLoginResponseApi>(
+    val response = restClient.post<JellyseerrLoginRequestBodyApi, JellyfinLoginResponseApi>(
       url = url,
-      body = JellyfinLoginRequestBodyApi(
+      body = JellyseerrLoginRequestBodyApi.Jellyfin(
         username = jellyfinLogin.username.value,
         password = jellyfinLogin.password.value,
       ),
@@ -35,7 +34,7 @@ class ProdJellyseerrService(private val restClient: JellyseerrRestClient) : Jell
 
     val response = restClient.post<JellyseerrLoginRequestBodyApi, JellyfinLoginResponseApi>(
       url = url,
-      body = JellyseerrLoginRequestBodyApi(
+      body = JellyseerrLoginRequestBodyApi.Jellyseerr(
         email = jellyseerrLogin.username.value,
         password = jellyseerrLogin.password.value,
       ),

--- a/core/network/src/test/kotlin/com/divinelink/core/network/client/JellyseerrRestClientTest.kt
+++ b/core/network/src/test/kotlin/com/divinelink/core/network/client/JellyseerrRestClientTest.kt
@@ -1,0 +1,313 @@
+package com.divinelink.core.network.client
+
+import com.divinelink.core.datastore.EncryptedStorage
+import com.divinelink.core.datastore.PreferenceStorage
+import com.divinelink.core.model.exception.JellyseerrInvalidCredentials
+import com.divinelink.core.model.exception.JellyseerrUnauthorizedException
+import com.divinelink.core.model.jellyseerr.JellyseerrLoginMethod
+import com.divinelink.core.network.jellyseerr.model.JellyseerrRequestMediaBodyApi
+import com.divinelink.core.network.jellyseerr.model.JellyseerrResponseBodyApi
+import com.divinelink.core.testing.factories.api.jellyseerr.JellyseerrRequestMediaBodyApiFactory
+import com.divinelink.core.testing.storage.FakeEncryptedPreferenceStorage
+import com.divinelink.core.testing.storage.FakePreferenceStorage
+import com.google.common.truth.Truth.assertThat
+import io.ktor.client.engine.HttpClientEngine
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.http.HttpMethod
+import io.ktor.http.HttpStatusCode
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+
+class JellyseerrRestClientTest {
+
+  private lateinit var client: JellyseerrRestClient
+  private lateinit var encryptedStorage: EncryptedStorage
+  private lateinit var datastore: PreferenceStorage
+  private lateinit var engine: HttpClientEngine
+
+  private val address = "http://localhost:8080"
+
+  @Test
+  fun `test unauthorized request triggers reAuthentication`() = runTest {
+    val requestHistory = mutableListOf<Pair<String, HttpStatusCode>>()
+
+    val expectedRequests = listOf(
+      "http://localhost:8080/api/v1/request" to HttpStatusCode.Unauthorized,
+      "http://localhost:8080/api/v1/auth/local" to HttpStatusCode.OK,
+      "http://localhost:8080/api/v1/request" to HttpStatusCode.OK,
+    )
+
+    var requestCount = 0
+
+    engine = MockEngine { request ->
+      when (request.method) {
+        HttpMethod.Get -> respond(
+          content = "Failed to authenticate",
+          status = HttpStatusCode.Unauthorized,
+        )
+        HttpMethod.Post -> {
+          val response = if (requestCount == 0) {
+            respond(
+              content = "Failed to authenticate",
+              status = HttpStatusCode.Unauthorized,
+            )
+          } else {
+            respond(
+              content = """{"success": true}""",
+              status = HttpStatusCode.OK,
+            )
+          }
+          requestCount++
+          response.also { requestHistory.add(request.url.toString() to response.statusCode) }
+        }
+        else -> error("Unexpected request method: ${request.method}")
+      }
+    }
+
+    encryptedStorage = FakeEncryptedPreferenceStorage(
+      jellyseerrPassword = "testPassword",
+    )
+    datastore = FakePreferenceStorage(
+      jellyseerrAccount = "testAccount",
+      jellyseerrAddress = address,
+      jellyseerrSignInMethod = JellyseerrLoginMethod.JELLYSEERR.name,
+    )
+
+    client = JellyseerrRestClient(
+      engine = engine,
+      encryptedStorage = encryptedStorage,
+      datastore = datastore,
+    )
+
+    // Initial request
+    client.post<JellyseerrRequestMediaBodyApi, JellyseerrResponseBodyApi>(
+      url = "http://localhost:8080/api/v1/request",
+      body = JellyseerrRequestMediaBodyApiFactory.movie(),
+    )
+
+    assertThat(requestHistory.size).isEqualTo(3)
+    assertThat(requestHistory).isEqualTo(expectedRequests)
+  }
+
+  @Test
+  fun `test reAuthentication with invalidCredentials throws UnauthorizedException`() = runTest {
+    val requestHistory = mutableListOf<Pair<String, HttpStatusCode>>()
+
+    val expectedRequests = listOf(
+      "http://localhost:8080/api/v1/request" to HttpStatusCode.Unauthorized,
+      "http://localhost:8080/api/v1/auth/local" to HttpStatusCode.Unauthorized,
+      "http://localhost:8080/api/v1/request" to HttpStatusCode.Unauthorized,
+      "http://localhost:8080/api/v1/auth/local" to HttpStatusCode.Unauthorized,
+    )
+
+    engine = MockEngine { request ->
+      when (request.method) {
+        HttpMethod.Get -> respond(
+          content = "Failed to authenticate",
+          status = HttpStatusCode.Unauthorized,
+        )
+        HttpMethod.Post -> {
+          respond(
+            content = "Failed to authenticate",
+            status = HttpStatusCode.Unauthorized,
+          ).also {
+            requestHistory.add(request.url.toString() to it.statusCode)
+          }
+        }
+        else -> error("Unexpected request method: ${request.method}")
+      }
+    }
+
+    encryptedStorage = FakeEncryptedPreferenceStorage(
+      jellyseerrPassword = "testPassword",
+    )
+    datastore = FakePreferenceStorage(
+      jellyseerrAccount = "testAccount",
+      jellyseerrAddress = address,
+      jellyseerrSignInMethod = JellyseerrLoginMethod.JELLYSEERR.name,
+    )
+
+    client = JellyseerrRestClient(
+      engine = engine,
+      encryptedStorage = encryptedStorage,
+      datastore = datastore,
+    )
+
+    assertFailsWith<JellyseerrUnauthorizedException> {
+      client.post<JellyseerrRequestMediaBodyApi, JellyseerrResponseBodyApi>(
+        url = "http://localhost:8080/api/v1/request",
+        body = JellyseerrRequestMediaBodyApiFactory.movie(),
+      )
+    }
+
+    assertThat(requestHistory.size).isEqualTo(4)
+    assertThat(requestHistory).isEqualTo(expectedRequests)
+  }
+
+  @Test
+  fun `test reAuthentication without password throws InvalidCredentials`() = runTest {
+    engine = MockEngine {
+      respond(
+        content = "Failed to authenticate",
+        status = HttpStatusCode.Unauthorized,
+      )
+    }
+
+    encryptedStorage = FakeEncryptedPreferenceStorage(
+      jellyseerrPassword = null,
+    )
+
+    datastore = FakePreferenceStorage(
+      jellyseerrAccount = "testAccount",
+      jellyseerrAddress = address,
+      jellyseerrSignInMethod = JellyseerrLoginMethod.JELLYSEERR.name,
+    )
+
+    client = JellyseerrRestClient(
+      engine = engine,
+      encryptedStorage = encryptedStorage,
+      datastore = datastore,
+    )
+
+    assertFailsWith<JellyseerrInvalidCredentials> {
+      client.post<JellyseerrRequestMediaBodyApi, JellyseerrResponseBodyApi>(
+        url = "http://localhost:8080/api/v1/request",
+        body = JellyseerrRequestMediaBodyApiFactory.movie(),
+      )
+    }
+  }
+
+  @Test
+  fun `test reAuthentication without account throws InvalidCredentials`() = runTest {
+    engine = MockEngine {
+      respond(
+        content = "Failed to authenticate",
+        status = HttpStatusCode.Unauthorized,
+      )
+    }
+
+    encryptedStorage = FakeEncryptedPreferenceStorage(
+      jellyseerrPassword = "testPassword",
+    )
+
+    datastore = FakePreferenceStorage(
+      jellyseerrAccount = null,
+      jellyseerrAddress = address,
+      jellyseerrSignInMethod = JellyseerrLoginMethod.JELLYSEERR.name,
+    )
+
+    client = JellyseerrRestClient(
+      engine = engine,
+      encryptedStorage = encryptedStorage,
+      datastore = datastore,
+    )
+
+    assertFailsWith<JellyseerrInvalidCredentials> {
+      client.post<JellyseerrRequestMediaBodyApi, JellyseerrResponseBodyApi>(
+        url = "http://localhost:8080/api/v1/request",
+        body = JellyseerrRequestMediaBodyApiFactory.movie(),
+      )
+    }
+  }
+
+  @Test
+  fun `test reAuthentication without address throws InvalidCredentials`() = runTest {
+    engine = MockEngine {
+      respond(
+        content = "Failed to authenticate",
+        status = HttpStatusCode.Unauthorized,
+      )
+    }
+
+    encryptedStorage = FakeEncryptedPreferenceStorage(
+      jellyseerrPassword = "testPassword",
+    )
+
+    datastore = FakePreferenceStorage(
+      jellyseerrAccount = "testAccount",
+      jellyseerrAddress = null,
+      jellyseerrSignInMethod = JellyseerrLoginMethod.JELLYSEERR.name,
+    )
+
+    client = JellyseerrRestClient(
+      engine = engine,
+      encryptedStorage = encryptedStorage,
+      datastore = datastore,
+    )
+
+    assertFailsWith<JellyseerrInvalidCredentials> {
+      client.post<JellyseerrRequestMediaBodyApi, JellyseerrResponseBodyApi>(
+        url = "http://localhost:8080/api/v1/request",
+        body = JellyseerrRequestMediaBodyApiFactory.movie(),
+      )
+    }
+  }
+
+  @Test
+  fun `test reAuthentication without signInMethod throws InvalidCredentials`() = runTest {
+    engine = MockEngine {
+      respond(
+        content = "Failed to authenticate",
+        status = HttpStatusCode.Unauthorized,
+      )
+    }
+
+    encryptedStorage = FakeEncryptedPreferenceStorage(
+      jellyseerrPassword = "testPassword",
+    )
+
+    datastore = FakePreferenceStorage(
+      jellyseerrAccount = "testAccount",
+      jellyseerrAddress = address,
+      jellyseerrSignInMethod = null,
+    )
+
+    client = JellyseerrRestClient(
+      engine = engine,
+      encryptedStorage = encryptedStorage,
+      datastore = datastore,
+    )
+
+    assertFailsWith<JellyseerrInvalidCredentials> {
+      client.post<JellyseerrRequestMediaBodyApi, JellyseerrResponseBodyApi>(
+        url = "http://localhost:8080/api/v1/request",
+        body = JellyseerrRequestMediaBodyApiFactory.movie(),
+      )
+    }
+  }
+
+  @Test
+  fun `test reAuthentication with invalid sign in method throws InvalidCredentials`() = runTest {
+    engine = MockEngine {
+      respond(
+        content = "Failed to authenticate",
+        status = HttpStatusCode.Unauthorized,
+      )
+    }
+
+    encryptedStorage = FakeEncryptedPreferenceStorage(
+      jellyseerrPassword = "testPassword",
+    )
+
+    datastore = FakePreferenceStorage(
+      jellyseerrAccount = "testAccount",
+      jellyseerrAddress = address,
+      jellyseerrSignInMethod = "invalid method",
+    )
+
+    client = JellyseerrRestClient(
+      engine = engine,
+      encryptedStorage = encryptedStorage,
+      datastore = datastore,
+    )
+
+    assertFailsWith<JellyseerrInvalidCredentials> {
+      client.post<JellyseerrRequestMediaBodyApi, JellyseerrResponseBodyApi>(
+        url = "http://localhost:8080/api/v1/request",
+        body = JellyseerrRequestMediaBodyApiFactory.movie(),
+      )
+    }
+  }
+}

--- a/core/testing/build.gradle.kts
+++ b/core/testing/build.gradle.kts
@@ -35,10 +35,9 @@ dependencies {
 
   implementation(libs.kotlinx.datetime)
 
-  implementation(libs.ktor.client.mock)
+  api(libs.ktor.client.mock)
 
   api(libs.koin.test)
-//  implementation(libs.koin.android)
 
   api(libs.datastore)
   api(libs.datastore.core)

--- a/core/testing/src/main/kotlin/com/divinelink/core/testing/network/MockEngine.kt
+++ b/core/testing/src/main/kotlin/com/divinelink/core/testing/network/MockEngine.kt
@@ -2,14 +2,19 @@ package com.divinelink.core.testing.network
 
 import io.ktor.client.engine.mock.MockEngine
 import io.ktor.client.engine.mock.respond
+import io.ktor.http.Headers
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.headersOf
 
-fun MockEngine(content: String) = MockEngine {
+fun MockEngine(
+  content: String,
+  status: HttpStatusCode = HttpStatusCode.OK,
+  headers: Headers = headersOf(HttpHeaders.ContentType, "application/json"),
+) = MockEngine {
   respond(
     content = content,
-    status = HttpStatusCode.OK,
-    headers = headersOf(HttpHeaders.ContentType, "application/json"),
+    status = status,
+    headers = headers,
   )
 }

--- a/core/testing/src/main/kotlin/com/divinelink/core/testing/storage/FakeEncryptedPreferenceStorage.kt
+++ b/core/testing/src/main/kotlin/com/divinelink/core/testing/storage/FakeEncryptedPreferenceStorage.kt
@@ -6,6 +6,7 @@ open class FakeEncryptedPreferenceStorage(
   override var tmdbAuthToken: String = "",
   override var sessionId: String? = null,
   override var jellyseerrAuthCookie: String? = null,
+  override var jellyseerrPassword: String? = null,
 ) : EncryptedStorage {
 
   override suspend fun setTmdbAuthToken(key: String) {
@@ -26,5 +27,13 @@ open class FakeEncryptedPreferenceStorage(
 
   override suspend fun setJellyseerrAuthCookie(cookie: String) {
     this.jellyseerrAuthCookie = cookie
+  }
+
+  override suspend fun clearJellyseerrPassword() {
+    this.jellyseerrPassword = null
+  }
+
+  override suspend fun setJellyseerrPassword(password: String) {
+    this.jellyseerrPassword = password
   }
 }

--- a/core/testing/src/main/kotlin/com/divinelink/core/testing/usecase/FakeLogoutJellyseerrUseCase.kt
+++ b/core/testing/src/main/kotlin/com/divinelink/core/testing/usecase/FakeLogoutJellyseerrUseCase.kt
@@ -15,12 +15,8 @@ class FakeLogoutJellyseerrUseCase {
     mockFailure()
   }
 
-  private fun mockFailure() {
-    whenever(
-      mock.invoke(any()),
-    ).thenReturn(
-      flowOf(Result.failure(Exception())),
-    )
+  fun mockFailure(error: Throwable = Exception()) {
+    whenever(mock.invoke(any())).thenReturn(flowOf(Result.failure(error)))
   }
 
   fun mockSuccess(response: Flow<Result<String>>) {

--- a/core/testing/src/main/kotlin/com/divinelink/core/testing/usecase/FakeRequestMediaUseCase.kt
+++ b/core/testing/src/main/kotlin/com/divinelink/core/testing/usecase/FakeRequestMediaUseCase.kt
@@ -3,6 +3,7 @@ package com.divinelink.core.testing.usecase
 import com.divinelink.core.domain.jellyseerr.RequestMediaUseCase
 import com.divinelink.core.model.jellyseerr.request.JellyseerrMediaRequest
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
 import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
@@ -13,5 +14,13 @@ class FakeRequestMediaUseCase {
 
   fun mockSuccess(response: Flow<Result<JellyseerrMediaRequest>>) {
     whenever(mock.invoke(any())).thenReturn(response)
+  }
+
+  fun mockFailure(throwable: Throwable) {
+    whenever(
+      mock.invoke(any()),
+    ).thenReturn(
+      flowOf(Result.failure(throwable)),
+    )
   }
 }

--- a/core/ui/src/main/res/values/strings.xml
+++ b/core/ui/src/main/res/values/strings.xml
@@ -57,6 +57,8 @@
   <string name="core_ui_offline_title">You are offline</string>
   <string name="core_ui_offline_description">Please connect to the internet and try again.</string>
 
+  <string name="core_ui_jellyseerr_session_expired">Your jellyseerr session has expired. Please login again.</string>
+
   <!-- Accessibility -->
   <string name="core_ui_navigate_up_button_content_description">Navigate Up Button</string>
   <string name="core_ui_movie_image_placeholder">Movie image</string>

--- a/core/ui/src/main/res/values/strings.xml
+++ b/core/ui/src/main/res/values/strings.xml
@@ -57,7 +57,7 @@
   <string name="core_ui_offline_title">You are offline</string>
   <string name="core_ui_offline_description">Please connect to the internet and try again.</string>
 
-  <string name="core_ui_jellyseerr_session_expired">Your jellyseerr session has expired. Please login again.</string>
+  <string name="core_ui_jellyseerr_session_expired">Your Jellyseerr session has expired. Please login again.</string>
 
   <!-- Accessibility -->
   <string name="core_ui_navigate_up_button_content_description">Navigate Up Button</string>

--- a/feature/details/src/main/kotlin/com/divinelink/feature/details/media/ui/DetailsContent.kt
+++ b/feature/details/src/main/kotlin/com/divinelink/feature/details/media/ui/DetailsContent.kt
@@ -6,7 +6,6 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize

--- a/feature/details/src/main/kotlin/com/divinelink/feature/details/media/ui/DetailsViewModel.kt
+++ b/feature/details/src/main/kotlin/com/divinelink/feature/details/media/ui/DetailsViewModel.kt
@@ -1,5 +1,6 @@
 package com.divinelink.feature.details.media.ui
 
+import androidx.compose.material3.SnackbarDuration
 import androidx.compose.material3.SnackbarResult
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
@@ -350,6 +351,7 @@ class DetailsViewModel(
               setSnackbarMessage(
                 text = UIText.ResourceText(uiR.string.core_ui_jellyseerr_session_expired),
                 actionLabelText = UIText.ResourceText(uiR.string.core_ui_login),
+                duration = SnackbarDuration.Long,
                 snackbarResult = ::navigateToLogin,
               )
             }
@@ -386,6 +388,7 @@ class DetailsViewModel(
   private fun setSnackbarMessage(
     text: UIText,
     actionLabelText: UIText? = null,
+    duration: SnackbarDuration = SnackbarDuration.Short,
     snackbarResult: (SnackbarResult) -> Unit = {},
   ) {
     _viewState.update { viewState ->
@@ -393,6 +396,7 @@ class DetailsViewModel(
         snackbarMessage = SnackbarMessage.from(
           text = text,
           actionLabelText = actionLabelText,
+          duration = duration,
           onSnackbarResult = snackbarResult,
         ),
       )

--- a/feature/details/src/main/kotlin/com/divinelink/feature/details/media/ui/DetailsViewModel.kt
+++ b/feature/details/src/main/kotlin/com/divinelink/feature/details/media/ui/DetailsViewModel.kt
@@ -334,14 +334,14 @@ class DetailsViewModel(
       .onEach { result ->
         result.onSuccess { response ->
           response.message?.let { message ->
-            setSnackbarMessage(
-              UIText.StringText(message),
-            )
+            setSnackbarMessage(SnackbarMessage.from(text = UIText.StringText(message)))
           } ?: run {
             setSnackbarMessage(
-              UIText.ResourceText(
-                R.string.feature_details_jellyseerr_success_media_request,
-                viewState.value.mediaDetails?.title ?: "",
+              SnackbarMessage.from(
+                UIText.ResourceText(
+                  R.string.feature_details_jellyseerr_success_media_request,
+                  viewState.value.mediaDetails?.title ?: "",
+                ),
               ),
             )
           }
@@ -349,22 +349,28 @@ class DetailsViewModel(
           ErrorHandler.create(it) {
             on(403) {
               setSnackbarMessage(
-                text = UIText.ResourceText(uiR.string.core_ui_jellyseerr_session_expired),
-                actionLabelText = UIText.ResourceText(uiR.string.core_ui_login),
-                duration = SnackbarDuration.Long,
-                snackbarResult = ::navigateToLogin,
+                SnackbarMessage.from(
+                  text = UIText.ResourceText(uiR.string.core_ui_jellyseerr_session_expired),
+                  actionLabelText = UIText.ResourceText(uiR.string.core_ui_login),
+                  duration = SnackbarDuration.Long,
+                  onSnackbarResult = ::navigateToLogin,
+                ),
               )
             }
             on(409) {
               setSnackbarMessage(
-                text = UIText.ResourceText(R.string.feature_details_jellyseerr_request_exists),
+                SnackbarMessage.from(
+                  text = UIText.ResourceText(R.string.feature_details_jellyseerr_request_exists),
+                ),
               )
             }
             otherwise {
               setSnackbarMessage(
-                text = UIText.ResourceText(
-                  R.string.feature_details_jellyseerr_request_failed,
-                  viewState.value.mediaDetails?.title ?: "",
+                SnackbarMessage.from(
+                  text = UIText.ResourceText(
+                    R.string.feature_details_jellyseerr_request_failed,
+                    viewState.value.mediaDetails?.title ?: "",
+                  ),
                 ),
               )
             }
@@ -385,20 +391,10 @@ class DetailsViewModel(
     }
   }
 
-  private fun setSnackbarMessage(
-    text: UIText,
-    actionLabelText: UIText? = null,
-    duration: SnackbarDuration = SnackbarDuration.Short,
-    snackbarResult: (SnackbarResult) -> Unit = {},
-  ) {
+  private fun setSnackbarMessage(snackbarMessage: SnackbarMessage) {
     _viewState.update { viewState ->
       viewState.copy(
-        snackbarMessage = SnackbarMessage.from(
-          text = text,
-          actionLabelText = actionLabelText,
-          duration = duration,
-          onSnackbarResult = snackbarResult,
-        ),
+        snackbarMessage = snackbarMessage,
       )
     }
   }

--- a/feature/details/src/main/kotlin/com/divinelink/feature/details/media/ui/DetailsViewModel.kt
+++ b/feature/details/src/main/kotlin/com/divinelink/feature/details/media/ui/DetailsViewModel.kt
@@ -346,6 +346,13 @@ class DetailsViewModel(
           }
         }.onFailure {
           ErrorHandler.create(it) {
+            on(403) {
+              setSnackbarMessage(
+                text = UIText.ResourceText(uiR.string.core_ui_jellyseerr_session_expired),
+                actionLabelText = UIText.ResourceText(uiR.string.core_ui_login),
+                snackbarResult = ::navigateToLogin,
+              )
+            }
             on(409) {
               setSnackbarMessage(
                 text = UIText.ResourceText(R.string.feature_details_jellyseerr_request_exists),
@@ -376,9 +383,19 @@ class DetailsViewModel(
     }
   }
 
-  private fun setSnackbarMessage(text: UIText) {
+  private fun setSnackbarMessage(
+    text: UIText,
+    actionLabelText: UIText? = null,
+    snackbarResult: (SnackbarResult) -> Unit = {},
+  ) {
     _viewState.update { viewState ->
-      viewState.copy(snackbarMessage = SnackbarMessage.from(text))
+      viewState.copy(
+        snackbarMessage = SnackbarMessage.from(
+          text = text,
+          actionLabelText = actionLabelText,
+          onSnackbarResult = snackbarResult,
+        ),
+      )
     }
   }
 

--- a/feature/settings/src/main/kotlin/com/divinelink/feature/settings/app/account/jellyseerr/JellyseerrSettingsViewModel.kt
+++ b/feature/settings/src/main/kotlin/com/divinelink/feature/settings/app/account/jellyseerr/JellyseerrSettingsViewModel.kt
@@ -9,6 +9,7 @@ import com.divinelink.core.domain.jellyseerr.LoginJellyseerrUseCase
 import com.divinelink.core.domain.jellyseerr.LogoutJellyseerrUseCase
 import com.divinelink.core.model.Password
 import com.divinelink.core.model.Username
+import com.divinelink.core.model.exception.JellyseerrUnauthorizedException
 import com.divinelink.core.model.jellyseerr.JellyseerrLoginMethod
 import com.divinelink.core.model.jellyseerr.JellyseerrState
 import com.divinelink.core.model.jellyseerr.loginParams
@@ -139,8 +140,22 @@ class JellyseerrSettingsViewModel(
                   ),
                 )
               }
-            }.onFailure {
-              _uiState.setSnackbarMessage(UIText.ResourceText(uiR.string.core_ui_error_retry))
+            }.onFailure { throwable ->
+              ErrorHandler.create(throwable) {
+                on<JellyseerrUnauthorizedException> {
+                  _uiState.update {
+                    it.copy(
+                      jellyseerrState = JellyseerrState.Initial(
+                        address = "",
+                        isLoading = false,
+                      ),
+                    )
+                  }
+                }
+                otherwise {
+                  _uiState.setSnackbarMessage(UIText.ResourceText(uiR.string.core_ui_error_retry))
+                }
+              }
             }
           }
           .launchIn(viewModelScope)

--- a/feature/settings/src/test/kotlin/com/divinelink/feature/settings/app/account/jellyseerr/JellyseerrSettingsViewModelTestRobot.kt
+++ b/feature/settings/src/test/kotlin/com/divinelink/feature/settings/app/account/jellyseerr/JellyseerrSettingsViewModelTestRobot.kt
@@ -29,6 +29,10 @@ class JellyseerrSettingsViewModelTestRobot : ViewModelTestRobot<JellyseerrSettin
     loginJellyseerrUseCase.mockSuccess(flowOf(response))
   }
 
+  fun mockLogoutJellyseerrResponse(response: Result<String>) = apply {
+    logoutJellyseerrUseCase.mockSuccess(flowOf(response))
+  }
+
   fun mockJellyseerrAccountDetailsResponse(response: Result<JellyseerrAccountDetails?>) = apply {
     getJellyseerrDetailsUseCase.mockSuccess(response)
   }
@@ -51,6 +55,10 @@ class JellyseerrSettingsViewModelTestRobot : ViewModelTestRobot<JellyseerrSettin
 
   fun onLoginJellyseerr() = apply {
     viewModel.onJellyseerrInteraction(JellyseerrInteraction.OnLoginClick)
+  }
+
+  fun onLogoutJellyseerr() = apply {
+    viewModel.onJellyseerrInteraction(JellyseerrInteraction.OnLogoutClick)
   }
 
   fun onDismissSnackbar() = apply {


### PR DESCRIPTION
This pull requests addresses the expired cookie exception on Jellyseerr API. 

The issue was that the user would get an unauthorised exception on the Jellyseerr API calls when the cookie had expired after 1 month. To fix that, we added an interceptor on our ktor client that will silently re-authenticate the user after they get an unauthorised exception. In addition to that, we also had to add the user's account password on our `EncryptedPreferences` to know the credentials in order to make the login api. 

There's an edge case, where the password could have changed during that period. In that case, the user gets a 403 error, that prompts the user to re-login using the new credentials. 