### PR TITLE
[Expandable FAB] Introduce Expandable FAB Component on Details Screen

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -126,8 +126,6 @@ dependencies {
   implementation(libs.compose.ui.tooling)
   implementation(libs.compose.ui.tooling.preview)
 
-  implementation(libs.compose.coil)
-
   debugImplementation(libs.compose.ui.tooling.preview)
   debugImplementation(libs.compose.ui.test.manifest)
 

--- a/app/src/test/kotlin/com/andreolas/ui/details/DetailsContentTest.kt
+++ b/app/src/test/kotlin/com/andreolas/ui/details/DetailsContentTest.kt
@@ -13,11 +13,13 @@ import com.andreolas.factories.ReviewFactory
 import com.andreolas.factories.details.domain.model.account.AccountMediaDetailsFactory
 import com.andreolas.factories.details.domain.model.account.AccountMediaDetailsFactory.toWizard
 import com.andreolas.movierama.R
+import com.divinelink.core.model.details.DetailsMenuOptions
 import com.divinelink.core.model.details.video.Video
 import com.divinelink.core.model.details.video.VideoSite
 import com.divinelink.core.model.media.MediaType
 import com.divinelink.core.testing.ComposeTest
 import com.divinelink.core.testing.factories.model.details.MediaDetailsFactory
+import com.divinelink.core.testing.getString
 import com.divinelink.core.testing.setContentWithTheme
 import com.divinelink.core.ui.TestTags
 import com.divinelink.core.ui.TestTags.LOADING_CONTENT
@@ -26,7 +28,6 @@ import com.divinelink.core.ui.components.details.reviews.REVIEWS_LIST
 import com.divinelink.core.ui.components.details.videos.VIDEO_PLAYER_TAG
 import com.divinelink.feature.details.media.ui.DetailsContent
 import com.divinelink.feature.details.media.ui.DetailsViewState
-import com.divinelink.feature.details.media.ui.MOVIE_DETAILS_SCROLLABLE_LIST_TAG
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
@@ -145,7 +146,7 @@ class DetailsContentTest : ComposeTest() {
     val reviewsTitle = composeTestRule.activity.getString(uiR.string.details__reviews)
 
     composeTestRule
-      .onNodeWithTag(MOVIE_DETAILS_SCROLLABLE_LIST_TAG)
+      .onNodeWithTag(TestTags.Details.CONTENT_LIST)
       .performScrollToNode(
         hasText(reviewsTitle),
       )
@@ -464,6 +465,7 @@ class DetailsContentTest : ComposeTest() {
           mediaId = 0,
           mediaType = MediaType.MOVIE,
           mediaDetails = MediaDetailsFactory.FightClub(),
+          menuOptions = listOf(DetailsMenuOptions.SHARE),
         ),
         onNavigateUp = {},
         onMarkAsFavoriteClicked = {},
@@ -480,9 +482,7 @@ class DetailsContentTest : ComposeTest() {
     with(composeTestRule) {
       onNodeWithTag(TestTags.Menu.MENU_BUTTON_VERTICAL).performClick()
       onNodeWithTag(
-        TestTags.Menu.MENU_ITEM.format(
-          composeTestRule.activity.getString(uiR.string.core_ui_share),
-        ),
+        TestTags.Menu.MENU_ITEM.format(getString(uiR.string.core_ui_share)),
       )
         .assertIsDisplayed()
         .performClick()

--- a/app/src/test/kotlin/com/andreolas/ui/details/DetailsContentTest.kt
+++ b/app/src/test/kotlin/com/andreolas/ui/details/DetailsContentTest.kt
@@ -2,6 +2,7 @@ package com.andreolas.ui.details
 
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsNotDisplayed
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithContentDescription
@@ -13,6 +14,7 @@ import com.andreolas.factories.ReviewFactory
 import com.andreolas.factories.details.domain.model.account.AccountMediaDetailsFactory
 import com.andreolas.factories.details.domain.model.account.AccountMediaDetailsFactory.toWizard
 import com.andreolas.movierama.R
+import com.divinelink.core.model.details.DetailActionItem
 import com.divinelink.core.model.details.DetailsMenuOptions
 import com.divinelink.core.model.details.video.Video
 import com.divinelink.core.model.details.video.VideoSite
@@ -514,6 +516,80 @@ class DetailsContentTest : ComposeTest() {
       onNodeWithTag(TestTags.Menu.MENU_BUTTON_VERTICAL).performClick()
       onNodeWithTag(TestTags.Menu.DROPDOWN_MENU).assertDoesNotExist()
     }
+  }
+
+  @Test
+  fun `test open request dialog for tv show`() {
+    setContentWithTheme {
+      DetailsContent(
+        viewState = DetailsViewState(
+          mediaId = 0,
+          mediaType = MediaType.TV,
+          actionButtons = DetailActionItem.entries,
+          mediaDetails = MediaDetailsFactory.TheOffice(),
+        ),
+        onNavigateUp = {},
+        onMarkAsFavoriteClicked = {},
+        onSimilarMovieClicked = {},
+        onConsumeSnackbar = {},
+        onAddRateClicked = {},
+        onAddToWatchlistClicked = {},
+        requestMedia = {},
+        viewAllCreditsClicked = {},
+        onPersonClick = {},
+      )
+    }
+    composeTestRule
+      .onNodeWithText(getString(detailsR.string.feature_details_request))
+      .assertIsNotDisplayed()
+
+    composeTestRule
+      .onNodeWithTag(TestTags.Components.ExpandableFab.BUTTON)
+      .performClick()
+
+    composeTestRule
+      .onNodeWithText(getString(detailsR.string.feature_details_request))
+      .assertIsDisplayed()
+      .performClick()
+
+    composeTestRule.onNodeWithTag(TestTags.Dialogs.SELECT_SEASONS_DIALOG).assertIsDisplayed()
+  }
+
+  @Test
+  fun `test open request dialog for movie`() {
+    setContentWithTheme {
+      DetailsContent(
+        viewState = DetailsViewState(
+          mediaId = 0,
+          mediaType = MediaType.MOVIE,
+          actionButtons = DetailActionItem.entries,
+          mediaDetails = MediaDetailsFactory.FightClub(),
+        ),
+        onNavigateUp = {},
+        onMarkAsFavoriteClicked = {},
+        onSimilarMovieClicked = {},
+        onConsumeSnackbar = {},
+        onAddRateClicked = {},
+        onAddToWatchlistClicked = {},
+        requestMedia = {},
+        viewAllCreditsClicked = {},
+        onPersonClick = {},
+      )
+    }
+    composeTestRule
+      .onNodeWithText(getString(detailsR.string.feature_details_request))
+      .assertIsNotDisplayed()
+
+    composeTestRule
+      .onNodeWithTag(TestTags.Components.ExpandableFab.BUTTON)
+      .performClick()
+
+    composeTestRule
+      .onNodeWithText(getString(detailsR.string.feature_details_request))
+      .assertIsDisplayed()
+      .performClick()
+
+    composeTestRule.onNodeWithTag(TestTags.Dialogs.REQUEST_MOVIE_DIALOG).assertIsDisplayed()
   }
 
   private val reviews = ReviewFactory.ReviewList()

--- a/app/src/test/kotlin/com/andreolas/ui/details/DetailsScreenTest.kt
+++ b/app/src/test/kotlin/com/andreolas/ui/details/DetailsScreenTest.kt
@@ -6,7 +6,7 @@ import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
-import androidx.compose.ui.test.performScrollTo
+import androidx.compose.ui.test.performScrollToIndex
 import androidx.compose.ui.test.performScrollToNode
 import androidx.compose.ui.test.performTouchInput
 import androidx.compose.ui.test.swipeRight
@@ -34,7 +34,6 @@ import com.divinelink.core.ui.TestTags
 import com.divinelink.feature.credits.screens.destinations.CreditsScreenDestination
 import com.divinelink.feature.details.media.ui.DetailsScreen
 import com.divinelink.feature.details.media.ui.DetailsViewModel
-import com.divinelink.feature.details.media.ui.MOVIE_DETAILS_SCROLLABLE_LIST_TAG
 import com.divinelink.feature.details.media.ui.MediaDetailsResult
 import com.divinelink.feature.details.screens.destinations.DetailsScreenDestination
 import com.divinelink.feature.settings.screens.destinations.AccountSettingsScreenDestination
@@ -112,7 +111,7 @@ class DetailsScreenTest : ComposeTest() {
     }
 
     composeTestRule
-      .onNodeWithTag(MOVIE_DETAILS_SCROLLABLE_LIST_TAG)
+      .onNodeWithTag(TestTags.Details.CONTENT_LIST)
       .performScrollToNode(
         matcher = hasText(
           MediaItemFactory.MoviesList()[0].name,
@@ -316,9 +315,6 @@ class DetailsScreenTest : ComposeTest() {
     val requestMediaUseCase = FakeRequestMediaUseCase()
     val destinationsNavigator = FakeDestinationsNavigator()
 
-    var verifyNavigatedToCredits: Pair<Boolean, CreditsNavArguments?> = false to null
-    var verifyNavigatedToDetails = false
-
     // Initial navigation to Details screen
     destinationsNavigator.navigate(
       direction = DetailsScreenDestination(
@@ -379,8 +375,9 @@ class DetailsScreenTest : ComposeTest() {
     }
 
     with(composeTestRule) {
+      onNodeWithTag(TestTags.Details.CONTENT_LIST).performScrollToIndex(2)
+
       onNodeWithText(getString(R.string.core_ui_view_all))
-        .performScrollTo()
         .assertIsDisplayed()
         .performClick()
 

--- a/core/commons/src/main/kotlin/com/divinelink/core/commons/ErrorHandler.kt
+++ b/core/commons/src/main/kotlin/com/divinelink/core/commons/ErrorHandler.kt
@@ -13,8 +13,9 @@ class ErrorHandler private constructor() {
 
     fun create(
       throwable: Throwable,
-      actions: ErrorHandler.() -> Unit,
-    ) = ErrorHandler().apply(actions).handle(throwable)
+      skipGlobal: Boolean = false,
+      actions: ErrorHandler.() -> Unit = {},
+    ) = ErrorHandler().apply(actions).handle(throwable = throwable, skipGlobal = skipGlobal)
   }
 
   /**

--- a/core/datastore/src/main/java/com/divinelink/core/datastore/PreferenceStorage.kt
+++ b/core/datastore/src/main/java/com/divinelink/core/datastore/PreferenceStorage.kt
@@ -17,6 +17,7 @@ import com.divinelink.core.datastore.DataStorePreferenceStorage.PreferencesKeys.
 import com.divinelink.core.datastore.DataStorePreferenceStorage.PreferencesKeys.PREF_SELECTED_THEME
 import com.divinelink.core.designsystem.theme.Theme
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
 import timber.log.Timber
 
@@ -150,7 +151,7 @@ class DataStorePreferenceStorage(private val dataStore: DataStore<Preferences>) 
 
   override val hasSession: Flow<Boolean> = dataStore.data.map {
     it[PREF_HAS_SESSION] ?: false
-  }
+  }.distinctUntilChanged()
 
   override suspend fun clearAccountId() {
     dataStore.edit {

--- a/core/designsystem/src/main/res/values-night/material3_colors.xml
+++ b/core/designsystem/src/main/res/values-night/material3_colors.xml
@@ -29,8 +29,4 @@
   <color name="colorShadow">@color/dark_colorShadow</color>
   <color name="colorSurfaceTint">@color/dark_colorSurfaceTint</color>
   <color name="colorSurfaceTintColor">@color/dark_colorSurfaceTintColor</color>
-
-  <color name="colorSurface2">@color/dark_colorSurface2</color>
-
-  <color name="colorSurface_60">@color/dark_colorSurface_60</color>
 </resources>

--- a/core/designsystem/src/main/res/values-night/material3_colors_dark.xml
+++ b/core/designsystem/src/main/res/values-night/material3_colors_dark.xml
@@ -29,8 +29,4 @@
   <color name="dark_colorShadow">#000000</color>
   <color name="dark_colorSurfaceTint">#5BD5FA</color>
   <color name="dark_colorSurfaceTintColor">#5BD5FA</color>
-
-  <color name="dark_colorSurface2">#172224</color>
-
-  <color name="dark_colorSurface_60">#99FBFCFF</color>-->
 </resources>

--- a/core/designsystem/src/main/res/values/material3_colors.xml
+++ b/core/designsystem/src/main/res/values/material3_colors.xml
@@ -29,8 +29,4 @@
   <color name="colorShadow">@color/light_colorShadow</color>
   <color name="colorSurfaceTint">@color/light_colorSurfaceTint</color>
   <color name="colorSurfaceTintColor">@color/light_colorSurfaceTintColor</color>
-
-  <color name="colorSurface2">@color/light_colorSurface2</color>
-
-  <color name="colorSurface_60">@color/light_colorSurface_60</color>
 </resources>

--- a/core/designsystem/src/main/res/values/material3_colors_light.xml
+++ b/core/designsystem/src/main/res/values/material3_colors_light.xml
@@ -31,7 +31,4 @@
   <color name="light_colorShadow">#000000</color>
   <color name="light_colorSurfaceTint">#00677E</color>
   <color name="light_colorSurfaceTintColor">#00677E</color>
-
-  <color name="light_colorSurface2">#F0F9FE</color>
-  <color name="light_colorSurface_60">#99FBFCFF</color>
 </resources>

--- a/core/domain/src/main/kotlin/com/divinelink/core/domain/GetDetailsActionItemsUseCase.kt
+++ b/core/domain/src/main/kotlin/com/divinelink/core/domain/GetDetailsActionItemsUseCase.kt
@@ -1,0 +1,28 @@
+package com.divinelink.core.domain
+
+import com.divinelink.core.commons.domain.DispatcherProvider
+import com.divinelink.core.commons.domain.FlowUseCase
+import com.divinelink.core.datastore.PreferenceStorage
+import com.divinelink.core.model.details.DetailActionItem
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
+
+class GetDetailsActionItemsUseCase(
+  private val storage: PreferenceStorage,
+  val dispatcher: DispatcherProvider,
+) : FlowUseCase<Unit, List<DetailActionItem>>(dispatcher.io) {
+
+  override fun execute(parameters: Unit): Flow<Result<List<DetailActionItem>>> = combine(
+    storage.jellyseerrAccount,
+  ) { account ->
+
+    val menuItems = buildList {
+      add(DetailActionItem.RATE)
+      add(DetailActionItem.WATCHLIST)
+      account.firstOrNull()?.let {
+        add(DetailActionItem.REQUEST)
+      }
+    }
+    Result.success(menuItems)
+  }
+}

--- a/core/domain/src/main/kotlin/com/divinelink/core/domain/GetDropdownMenuItemsUseCase.kt
+++ b/core/domain/src/main/kotlin/com/divinelink/core/domain/GetDropdownMenuItemsUseCase.kt
@@ -13,6 +13,6 @@ class GetDropdownMenuItemsUseCase(val dispatcher: DispatcherProvider) :
     val menuItems = buildList {
       add(DetailsMenuOptions.SHARE)
     }
-    Result.success(menuItems)
+    emit(Result.success(menuItems))
   }
 }

--- a/core/domain/src/main/kotlin/com/divinelink/core/domain/GetDropdownMenuItemsUseCase.kt
+++ b/core/domain/src/main/kotlin/com/divinelink/core/domain/GetDropdownMenuItemsUseCase.kt
@@ -1,27 +1,18 @@
 package com.divinelink.core.domain
 
-import com.divinelink.core.commons.domain.FlowUseCase
-import com.divinelink.core.datastore.PreferenceStorage
-import com.divinelink.core.model.details.DetailsMenuOptions
 import com.divinelink.core.commons.domain.DispatcherProvider
+import com.divinelink.core.commons.domain.FlowUseCase
+import com.divinelink.core.model.details.DetailsMenuOptions
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.flow
 
-class GetDropdownMenuItemsUseCase(
-  private val storage: PreferenceStorage,
-  val dispatcher: DispatcherProvider,
-) : FlowUseCase<Unit, List<DetailsMenuOptions>>(dispatcher.io) {
+class GetDropdownMenuItemsUseCase(val dispatcher: DispatcherProvider) :
+  FlowUseCase<Unit, List<DetailsMenuOptions>>(dispatcher.io) {
 
-  override fun execute(parameters: Unit): Flow<Result<List<DetailsMenuOptions>>> = combine(
-    storage.jellyseerrAccount,
-  ) { account ->
-    val menuItems = mutableListOf<DetailsMenuOptions>()
-    menuItems.add(DetailsMenuOptions.SHARE)
-
-    account.firstOrNull()?.let {
-      menuItems.add(DetailsMenuOptions.REQUEST)
+  override fun execute(parameters: Unit): Flow<Result<List<DetailsMenuOptions>>> = flow {
+    val menuItems = buildList {
+      add(DetailsMenuOptions.SHARE)
     }
-
     Result.success(menuItems)
   }
 }

--- a/core/domain/src/main/kotlin/com/divinelink/core/domain/di/UseCaseModule.kt
+++ b/core/domain/src/main/kotlin/com/divinelink/core/domain/di/UseCaseModule.kt
@@ -1,12 +1,13 @@
 package com.divinelink.core.domain.di
 
 import com.divinelink.core.domain.CreateRequestTokenUseCase
-import com.divinelink.core.domain.change.FetchChangesUseCase
 import com.divinelink.core.domain.FetchWatchlistUseCase
 import com.divinelink.core.domain.GetAccountDetailsUseCase
 import com.divinelink.core.domain.GetDropdownMenuItemsUseCase
+import com.divinelink.core.domain.GetDetailsActionItemsUseCase
 import com.divinelink.core.domain.HandleAuthenticationRequestUseCase
 import com.divinelink.core.domain.MarkAsFavoriteUseCase
+import com.divinelink.core.domain.change.FetchChangesUseCase
 import com.divinelink.core.domain.credits.FetchCreditsUseCase
 import com.divinelink.core.domain.details.person.FetchPersonDetailsUseCase
 import com.divinelink.core.domain.jellyseerr.GetJellyseerrAccountDetailsUseCase
@@ -43,6 +44,7 @@ val useCaseModule = module {
   factoryOf(::FetchWatchlistUseCase)
   factoryOf(::GetAccountDetailsUseCase)
   factoryOf(::GetDropdownMenuItemsUseCase)
+  factoryOf(::GetDetailsActionItemsUseCase)
   factoryOf(::HandleAuthenticationRequestUseCase)
   factoryOf(::MarkAsFavoriteUseCase)
 }

--- a/core/domain/src/main/kotlin/com/divinelink/core/domain/jellyseerr/GetJellyseerrAccountDetailsUseCase.kt
+++ b/core/domain/src/main/kotlin/com/divinelink/core/domain/jellyseerr/GetJellyseerrAccountDetailsUseCase.kt
@@ -24,7 +24,11 @@ class GetJellyseerrAccountDetailsUseCase(
 
     launch {
       repository.getLocalJellyseerrAccountDetails().collect { localDetails ->
-        send(Result.success(localDetails))
+        if (storage.jellyseerrAddress.first() == null) {
+          send(Result.success(null))
+        } else {
+          send(Result.success(localDetails))
+        }
       }
     }
 

--- a/core/domain/src/main/kotlin/com/divinelink/core/domain/jellyseerr/GetJellyseerrAccountDetailsUseCase.kt
+++ b/core/domain/src/main/kotlin/com/divinelink/core/domain/jellyseerr/GetJellyseerrAccountDetailsUseCase.kt
@@ -7,7 +7,7 @@ import com.divinelink.core.datastore.PreferenceStorage
 import com.divinelink.core.model.jellyseerr.JellyseerrAccountDetails
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.channelFlow
-import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 
 class GetJellyseerrAccountDetailsUseCase(
@@ -20,30 +20,25 @@ class GetJellyseerrAccountDetailsUseCase(
    * @param parameters: If true, fetch from remote
    */
   override fun execute(parameters: Boolean): Flow<Result<JellyseerrAccountDetails?>> = channelFlow {
-    val address = storage.jellyseerrAddress.firstOrNull()
+    val address = storage.jellyseerrAddress.first()
 
     launch {
-      repository
-        .getLocalJellyseerrAccountDetails()
-        .collect { details ->
-          if (address == null) {
-            send(Result.failure(Exception("No address found.")))
-          } else {
-            send(Result.success(details))
-          }
-        }
+      repository.getLocalJellyseerrAccountDetails().collect { localDetails ->
+        send(Result.success(localDetails))
+      }
     }
 
     launch {
       if (parameters && address != null) {
-        repository.getRemoteAccountDetails(address).collect { remoteResult ->
-          remoteResult.onSuccess { remoteDetails ->
-            repository.insertJellyseerrAccountDetails(remoteDetails)
-            send(Result.success(remoteDetails))
-          }.onFailure { error ->
-            send(Result.failure(error))
-          }
-        }
+        repository.getRemoteAccountDetails(address).first().fold(
+          onSuccess = {
+            repository.insertJellyseerrAccountDetails(it)
+            send(Result.success(it))
+          },
+          onFailure = {
+            send(Result.failure(it))
+          },
+        )
       }
     }
   }

--- a/core/domain/src/main/kotlin/com/divinelink/core/domain/jellyseerr/LoginJellyseerrUseCase.kt
+++ b/core/domain/src/main/kotlin/com/divinelink/core/domain/jellyseerr/LoginJellyseerrUseCase.kt
@@ -8,6 +8,7 @@ import com.divinelink.core.model.jellyseerr.JellyseerrAccountDetails
 import com.divinelink.core.model.jellyseerr.JellyseerrAuthMethod
 import com.divinelink.core.model.jellyseerr.JellyseerrLoginParams
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.last
 
@@ -35,19 +36,17 @@ open class LoginJellyseerrUseCase(
 
       result.last().fold(
         onSuccess = {
-          repository.getRemoteAccountDetails(parameters.address).collect { result ->
-            val accountDetails = result.getOrThrow()
+          val details = repository.getRemoteAccountDetails(parameters.address).first().getOrThrow()
 
-            storage.setJellyseerrSession(
-              username = parameters.username.value,
-              address = parameters.address,
-              authMethod = parameters.authMethod.name,
-              password = parameters.password.value,
-            )
-            repository.insertJellyseerrAccountDetails(accountDetails)
+          storage.setJellyseerrSession(
+            username = parameters.username.value,
+            address = parameters.address,
+            authMethod = parameters.authMethod.name,
+            password = parameters.password.value,
+          )
+          repository.insertJellyseerrAccountDetails(details)
 
-            emit(Result.success(accountDetails))
-          }
+          emit(Result.success(details))
         },
         onFailure = {
           emit(Result.failure(it))

--- a/core/domain/src/main/kotlin/com/divinelink/core/domain/session/ObserveSessionUseCase.kt
+++ b/core/domain/src/main/kotlin/com/divinelink/core/domain/session/ObserveSessionUseCase.kt
@@ -1,9 +1,9 @@
 package com.divinelink.core.domain.session
 
+import com.divinelink.core.commons.domain.DispatcherProvider
 import com.divinelink.core.commons.domain.FlowUseCase
 import com.divinelink.core.data.session.model.SessionException
 import com.divinelink.core.datastore.PreferenceStorage
-import com.divinelink.core.commons.domain.DispatcherProvider
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 

--- a/core/domain/src/test/kotlin/com/divinelink/core/domain/GetDetailsActionItemsUseCaseTest.kt
+++ b/core/domain/src/test/kotlin/com/divinelink/core/domain/GetDetailsActionItemsUseCaseTest.kt
@@ -1,0 +1,56 @@
+package com.divinelink.core.domain
+
+import com.divinelink.core.model.details.DetailActionItem
+import com.divinelink.core.testing.MainDispatcherRule
+import com.divinelink.core.testing.storage.FakePreferenceStorage
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.Rule
+import kotlin.test.Test
+
+class GetDetailsActionItemsUseCaseTest {
+
+  @get:Rule
+  val mainDispatcherRule = MainDispatcherRule()
+  private val testDispatcher = mainDispatcherRule.testDispatcher
+
+  @Test
+  fun `test detail action items without jellyseerr account`() = runTest {
+    val useCase = createGetDetailsActionItemsUseCase(FakePreferenceStorage())
+
+    useCase.invoke(Unit).first().let { result ->
+      assertThat(result.isSuccess).isTrue()
+      assertThat(result.getOrNull()).isEqualTo(
+        listOf(
+          DetailActionItem.RATE,
+          DetailActionItem.WATCHLIST,
+        ),
+      )
+    }
+  }
+
+  @Test
+  fun `test detail action items with jellyseerr account`() = runTest {
+    val useCase = createGetDetailsActionItemsUseCase(
+      FakePreferenceStorage(jellyseerrAccount = "jellyseerr_account"),
+    )
+
+    useCase.invoke(Unit).first().let { result ->
+      assertThat(result.isSuccess).isTrue()
+      assertThat(result.getOrNull()).isEqualTo(
+        listOf(
+          DetailActionItem.RATE,
+          DetailActionItem.WATCHLIST,
+          DetailActionItem.REQUEST,
+        ),
+      )
+    }
+  }
+
+  private fun createGetDetailsActionItemsUseCase(storage: FakePreferenceStorage) =
+    GetDetailsActionItemsUseCase(
+      storage = storage,
+      dispatcher = testDispatcher,
+    )
+}

--- a/core/domain/src/test/kotlin/com/divinelink/core/domain/GetDropdownMenuItemsUseCaseTest.kt
+++ b/core/domain/src/test/kotlin/com/divinelink/core/domain/GetDropdownMenuItemsUseCaseTest.kt
@@ -2,7 +2,6 @@ package com.divinelink.core.domain
 
 import com.divinelink.core.model.details.DetailsMenuOptions
 import com.divinelink.core.testing.MainDispatcherRule
-import com.divinelink.core.testing.storage.FakePreferenceStorage
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
@@ -17,28 +16,27 @@ class GetDropdownMenuItemsUseCaseTest {
 
   @Test
   fun `test dropdown menu items without jellyseerr account`() = runTest {
-    val preferenceStorage = FakePreferenceStorage(jellyseerrAccount = null)
-    val useCase = GetDropdownMenuItemsUseCase(preferenceStorage, testDispatcher)
+    val useCase = GetDropdownMenuItemsUseCase(testDispatcher)
 
     useCase.invoke(Unit).first().let { result ->
       assertThat(result.isSuccess).isTrue()
       assertThat(result.getOrNull()).isEqualTo(listOf(DetailsMenuOptions.SHARE))
     }
   }
-
-  @Test
-  fun `test dropdown menu items with jellyseerr account`() = runTest {
-    val preferenceStorage = FakePreferenceStorage(jellyseerrAccount = "jellyseerr_account")
-    val useCase = GetDropdownMenuItemsUseCase(preferenceStorage, testDispatcher)
-
-    useCase.invoke(Unit).first().let { result ->
-      assertThat(result.isSuccess).isTrue()
-      assertThat(result.getOrNull()).isEqualTo(
-        listOf(
-          DetailsMenuOptions.SHARE,
-          DetailsMenuOptions.REQUEST,
-        ),
-      )
-    }
-  }
+//
+//  @Test
+//  fun `test dropdown menu items with jellyseerr account`() = runTest {
+//    val preferenceStorage = FakePreferenceStorage(jellyseerrAccount = "jellyseerr_account")
+//    val useCase = GetDropdownMenuItemsUseCase(preferenceStorage, testDispatcher)
+//
+//    useCase.invoke(Unit).first().let { result ->
+//      assertThat(result.isSuccess).isTrue()
+//      assertThat(result.getOrNull()).isEqualTo(
+//        listOf(
+//          DetailsMenuOptions.SHARE,
+//          DetailsMenuOptions.REQUEST,
+//        ),
+//      )
+//    }
+//  }
 }

--- a/core/domain/src/test/kotlin/com/divinelink/core/domain/GetDropdownMenuItemsUseCaseTest.kt
+++ b/core/domain/src/test/kotlin/com/divinelink/core/domain/GetDropdownMenuItemsUseCaseTest.kt
@@ -23,20 +23,4 @@ class GetDropdownMenuItemsUseCaseTest {
       assertThat(result.getOrNull()).isEqualTo(listOf(DetailsMenuOptions.SHARE))
     }
   }
-//
-//  @Test
-//  fun `test dropdown menu items with jellyseerr account`() = runTest {
-//    val preferenceStorage = FakePreferenceStorage(jellyseerrAccount = "jellyseerr_account")
-//    val useCase = GetDropdownMenuItemsUseCase(preferenceStorage, testDispatcher)
-//
-//    useCase.invoke(Unit).first().let { result ->
-//      assertThat(result.isSuccess).isTrue()
-//      assertThat(result.getOrNull()).isEqualTo(
-//        listOf(
-//          DetailsMenuOptions.SHARE,
-//          DetailsMenuOptions.REQUEST,
-//        ),
-//      )
-//    }
-//  }
 }

--- a/core/domain/src/test/kotlin/com/divinelink/core/domain/jellyseerr/GetJellyseerrDetailsUseCaseTest.kt
+++ b/core/domain/src/test/kotlin/com/divinelink/core/domain/jellyseerr/GetJellyseerrDetailsUseCaseTest.kt
@@ -36,10 +36,10 @@ class GetJellyseerrDetailsUseCaseTest {
       dispatcher = testDispatcher,
     )
 
-    val result = useCase.invoke(false).first()
-
-    assertThat(result.isFailure).isTrue()
-    assertThat(result.exceptionOrNull()).isInstanceOf(Exception::class.java)
+    useCase.invoke(false).test {
+      assertThat(awaitItem()).isEqualTo(Result.success(null))
+      awaitComplete()
+    }
   }
 
   @Test
@@ -83,10 +83,10 @@ class GetJellyseerrDetailsUseCaseTest {
       dispatcher = testDispatcher,
     )
 
-    val result = useCase.invoke(true).first()
-
-    assertThat(result.isFailure).isTrue()
-    assertThat(result.exceptionOrNull()).isInstanceOf(Exception::class.java)
+    useCase.invoke(true).test {
+      assertThat(awaitItem()).isEqualTo(Result.success(null))
+      awaitComplete()
+    }
   }
 
   @Test

--- a/core/model/src/main/kotlin/com/divinelink/core/model/details/DetailActionItem.kt
+++ b/core/model/src/main/kotlin/com/divinelink/core/model/details/DetailActionItem.kt
@@ -1,0 +1,7 @@
+package com.divinelink.core.model.details
+
+enum class DetailActionItem {
+  RATE,
+  WATCHLIST,
+  REQUEST,
+}

--- a/core/model/src/main/kotlin/com/divinelink/core/model/details/DetailsMenuOptions.kt
+++ b/core/model/src/main/kotlin/com/divinelink/core/model/details/DetailsMenuOptions.kt
@@ -2,5 +2,4 @@ package com.divinelink.core.model.details
 
 enum class DetailsMenuOptions {
   SHARE,
-  REQUEST,
 }

--- a/core/model/src/main/kotlin/com/divinelink/core/model/jellyseerr/JellyseerrState.kt
+++ b/core/model/src/main/kotlin/com/divinelink/core/model/jellyseerr/JellyseerrState.kt
@@ -4,8 +4,6 @@ sealed class JellyseerrState(
   open var jellyfinLogin: JellyseerrLoginData = JellyseerrLoginData.empty(),
   open var jellyseerrLogin: JellyseerrLoginData = JellyseerrLoginData.empty(),
 ) {
-  data object Loading : JellyseerrState()
-
   data class Initial(
     val address: String,
     val isLoading: Boolean,

--- a/core/testing/src/main/kotlin/com/divinelink/core/testing/usecase/FakeGetDetailsActionItemsUseCase.kt
+++ b/core/testing/src/main/kotlin/com/divinelink/core/testing/usecase/FakeGetDetailsActionItemsUseCase.kt
@@ -1,0 +1,30 @@
+package com.divinelink.core.testing.usecase
+
+import com.divinelink.core.domain.GetDetailsActionItemsUseCase
+import com.divinelink.core.model.details.DetailActionItem
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+class FakeGetDetailsActionItemsUseCase {
+
+  val mock: GetDetailsActionItemsUseCase = mock()
+
+  init {
+    mockFailure()
+  }
+
+  fun mockFailure() {
+    whenever(
+      mock.invoke(any()),
+    ).thenReturn(
+      flowOf(Result.failure(Exception())),
+    )
+  }
+
+  fun mockSuccess(response: Flow<Result<List<DetailActionItem>>>) {
+    whenever(mock.invoke(any())).thenReturn(response)
+  }
+}

--- a/core/ui/build.gradle.kts
+++ b/core/ui/build.gradle.kts
@@ -15,7 +15,8 @@ dependencies {
 
   implementation(projects.core.commons)
 
-  implementation(libs.compose.coil)
+  implementation(libs.coil)
+  implementation(libs.coil.ktor)
 
   implementation(libs.androidx.lifecycle.runtime.ktx)
   implementation(libs.youtube.player)

--- a/core/ui/src/main/kotlin/com/divinelink/core/ui/CoilImage.kt
+++ b/core/ui/src/main/kotlin/com/divinelink/core/ui/CoilImage.kt
@@ -1,5 +1,3 @@
-@file:Suppress("MagicNumber")
-
 package com.divinelink.core.ui
 
 import androidx.compose.foundation.shape.CircleShape

--- a/core/ui/src/main/kotlin/com/divinelink/core/ui/DetailsDropdownMenu.kt
+++ b/core/ui/src/main/kotlin/com/divinelink/core/ui/DetailsDropdownMenu.kt
@@ -1,12 +1,9 @@
 package com.divinelink.core.ui
 
 import android.content.Intent
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.material3.DropdownMenu
-import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Surface
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -15,31 +12,22 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
-import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.divinelink.core.designsystem.theme.AppTheme
 import com.divinelink.core.model.credits.PersonRole
-import com.divinelink.core.model.details.DetailsMenuOptions
 import com.divinelink.core.model.details.MediaDetails
 import com.divinelink.core.model.details.Movie
 import com.divinelink.core.model.details.Person
-import com.divinelink.core.model.details.TV
 import com.divinelink.core.model.details.shareUrl
-import com.divinelink.core.ui.components.dialog.RequestMovieDialog
-import com.divinelink.core.ui.components.dialog.SelectSeasonsDialog
 import com.divinelink.core.ui.components.dropdownmenu.ShareMenuItem
 
 @Composable
 fun DetailsDropdownMenu(
   mediaDetails: MediaDetails,
-  menuOptions: List<DetailsMenuOptions>,
   expanded: Boolean,
-  requestMedia: (List<Int>) -> Unit,
   onDismissDropdown: () -> Unit,
 ) {
   var showShareDialog by remember { mutableStateOf(false) }
-  var showRequestDialog by remember { mutableStateOf(false) }
 
   if (showShareDialog) {
     val shareIntent = Intent(Intent.ACTION_SEND).apply {
@@ -48,27 +36,6 @@ fun DetailsDropdownMenu(
     }
     LocalContext.current.startActivity(Intent.createChooser(shareIntent, "Share via"))
     showShareDialog = false
-  }
-
-  if (showRequestDialog) {
-    when (mediaDetails) {
-      is TV -> SelectSeasonsDialog(
-        numberOfSeasons = mediaDetails.numberOfSeasons,
-        onRequestClick = {
-          requestMedia(it)
-          showRequestDialog = false
-        },
-        onDismissRequest = { showRequestDialog = false },
-      )
-      is Movie -> RequestMovieDialog(
-        onDismissRequest = { showRequestDialog = false },
-        onConfirm = {
-          requestMedia(emptyList())
-          showRequestDialog = false
-        },
-        title = mediaDetails.title,
-      )
-    }
   }
 
   DropdownMenu(
@@ -84,25 +51,6 @@ fun DetailsDropdownMenu(
         showShareDialog = true
       },
     )
-
-    if (menuOptions.contains(DetailsMenuOptions.REQUEST)) {
-      DropdownMenuItem(
-        modifier = Modifier.testTag(
-          TestTags.Menu.MENU_ITEM.format(stringResource(R.string.core_ui_dropdown_menu_request)),
-        ),
-        leadingIcon = {
-          Image(
-            painter = painterResource(id = R.drawable.core_ui_ic_jellyseerr),
-            contentDescription = null,
-          )
-        },
-        text = { Text(text = stringResource(id = R.string.core_ui_dropdown_menu_request)) },
-        onClick = {
-          onDismissDropdown()
-          showRequestDialog = true
-        },
-      )
-    }
   }
 }
 
@@ -131,8 +79,6 @@ private fun DetailsDropdownMenuPreview() {
           genres = listOf("Thriller", "Drama", "Comedy"),
           runtime = "2h 10m",
         ),
-        menuOptions = listOf(DetailsMenuOptions.SHARE, DetailsMenuOptions.REQUEST),
-        requestMedia = {},
         expanded = true,
         onDismissDropdown = {},
       )

--- a/core/ui/src/main/kotlin/com/divinelink/core/ui/DetailsDropdownMenu.kt
+++ b/core/ui/src/main/kotlin/com/divinelink/core/ui/DetailsDropdownMenu.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import com.divinelink.core.designsystem.theme.AppTheme
 import com.divinelink.core.model.credits.PersonRole
+import com.divinelink.core.model.details.DetailsMenuOptions
 import com.divinelink.core.model.details.MediaDetails
 import com.divinelink.core.model.details.Movie
 import com.divinelink.core.model.details.Person
@@ -24,6 +25,7 @@ import com.divinelink.core.ui.components.dropdownmenu.ShareMenuItem
 @Composable
 fun DetailsDropdownMenu(
   mediaDetails: MediaDetails,
+  options: List<DetailsMenuOptions>,
   expanded: Boolean,
   onDismissDropdown: () -> Unit,
 ) {
@@ -45,12 +47,16 @@ fun DetailsDropdownMenu(
     expanded = expanded,
     onDismissRequest = onDismissDropdown,
   ) {
-    ShareMenuItem(
-      onClick = {
-        onDismissDropdown()
-        showShareDialog = true
-      },
-    )
+    options.forEach { option ->
+      when (option) {
+        DetailsMenuOptions.SHARE -> ShareMenuItem(
+          onClick = {
+            onDismissDropdown()
+            showShareDialog = true
+          },
+        )
+      }
+    }
   }
 }
 
@@ -80,6 +86,7 @@ private fun DetailsDropdownMenuPreview() {
           runtime = "2h 10m",
         ),
         expanded = true,
+        options = DetailsMenuOptions.entries,
         onDismissDropdown = {},
       )
     }

--- a/core/ui/src/main/kotlin/com/divinelink/core/ui/TestTags.kt
+++ b/core/ui/src/main/kotlin/com/divinelink/core/ui/TestTags.kt
@@ -12,6 +12,11 @@ object TestTags {
       const val TOP_APP_BAR = "Top App Bar"
       const val TOP_APP_BAR_TITLE = "Top App Bar Title"
     }
+
+    object ExpandableFab {
+      const val BACKGROUND = "Floating Button Background"
+      const val BUTTON = "Expandable Floating Action Button"
+    }
   }
 
   const val LOADING_CONTENT = "LOADING_CONTENT"

--- a/core/ui/src/main/kotlin/com/divinelink/core/ui/TestTags.kt
+++ b/core/ui/src/main/kotlin/com/divinelink/core/ui/TestTags.kt
@@ -23,6 +23,7 @@ object TestTags {
   const val LAZY_COLUMN = "Lazy Column"
 
   object Details {
+    const val CONTENT_LIST = "Details Content Scrollable List"
     const val CONTENT_SCAFFOLD = "Details Content Scaffold"
     const val SIMILAR_MOVIES_LIST = "Details Similar Movies Lazy List"
 

--- a/core/ui/src/main/kotlin/com/divinelink/core/ui/components/details/SpannableRating.kt
+++ b/core/ui/src/main/kotlin/com/divinelink/core/ui/components/details/SpannableRating.kt
@@ -85,10 +85,26 @@ private fun SpannableRatingText(
 fun SpannableRatingPreview() {
   AppTheme {
     Surface {
-      SpannableRating(
-        text = "Your rating",
-        rating = "8",
-      )
+      Column(
+        verticalArrangement = Arrangement.spacedBy(MaterialTheme.dimensions.keyline_4),
+      ) {
+        SpannableRating(
+          text = "Your rating",
+          rating = "0",
+        )
+        SpannableRating(
+          text = "Your rating",
+          rating = "1",
+        )
+        SpannableRating(
+          text = "Your rating",
+          rating = "5",
+        )
+        SpannableRating(
+          text = "Your rating",
+          rating = "8",
+        )
+      }
     }
   }
 }
@@ -98,11 +114,30 @@ fun SpannableRatingPreview() {
 fun SpannableRatingNewLinePreview() {
   AppTheme {
     Surface {
-      SpannableRating(
-        text = "Your rating",
-        rating = "8",
-        vertical = true,
-      )
+      Column(
+        verticalArrangement = Arrangement.spacedBy(MaterialTheme.dimensions.keyline_4),
+      ) {
+        SpannableRating(
+          text = "Your rating",
+          rating = "0",
+          vertical = true,
+        )
+        SpannableRating(
+          text = "Your rating",
+          rating = "1",
+          vertical = true,
+        )
+        SpannableRating(
+          text = "Your rating",
+          rating = "5",
+          vertical = true,
+        )
+        SpannableRating(
+          text = "Your rating",
+          rating = "8",
+          vertical = true,
+        )
+      }
     }
   }
 }

--- a/core/ui/src/main/kotlin/com/divinelink/core/ui/components/expandablefab/ExpandableFloatingActionButton.kt
+++ b/core/ui/src/main/kotlin/com/divinelink/core/ui/components/expandablefab/ExpandableFloatingActionButton.kt
@@ -1,0 +1,199 @@
+package com.divinelink.core.ui.components.expandablefab
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Adb
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Brush
+import androidx.compose.material.icons.filled.Call
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.SmallFloatingActionButton
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.rotate
+import com.divinelink.core.designsystem.theme.AppTheme
+import com.divinelink.core.designsystem.theme.dimensions
+import com.divinelink.core.ui.Previews
+
+@Composable
+fun ExpandableFloatActionButton(buttons: List<FloatingActionButtonItem>) {
+  var expanded by remember { mutableStateOf(false) }
+  val rotationState by animateFloatAsState(
+    targetValue = if (expanded) 45f else 0f,
+    animationSpec = tween(durationMillis = 300),
+    label = "FAB Rotation Animation",
+  )
+
+  Box(modifier = Modifier.fillMaxSize()) {
+    AnimatedVisibility(
+      visible = expanded,
+      enter = fadeIn(animationSpec = tween(durationMillis = 300)),
+      exit = fadeOut(animationSpec = tween(durationMillis = 300)),
+    ) {
+      Box(
+        modifier = Modifier
+          .fillMaxSize()
+          .background(MaterialTheme.colorScheme.surface.copy(alpha = 0.9f))
+          .clickable { expanded = false },
+      )
+    }
+
+    Column(
+      horizontalAlignment = Alignment.End,
+      verticalArrangement = Arrangement.Bottom,
+      modifier = Modifier
+        .fillMaxSize()
+        .padding(MaterialTheme.dimensions.keyline_16),
+    ) {
+      StaggeredFloatingActionsButtons(
+        fabItems = buttons,
+        expanded = expanded,
+        onDismiss = { expanded = false },
+      )
+
+      Spacer(modifier = Modifier.padding(top = MaterialTheme.dimensions.keyline_8))
+
+      FloatingActionButton(
+        onClick = { expanded = !expanded },
+        modifier = Modifier.rotate(rotationState),
+      ) {
+        Icon(Icons.Filled.Add, contentDescription = "Expandable FAB")
+      }
+    }
+  }
+}
+
+@Composable
+private fun StaggeredFloatingActionsButtons(
+  fabItems: List<FloatingActionButtonItem>,
+  expanded: Boolean,
+  onDismiss: () -> Unit,
+) {
+  fabItems.forEachIndexed { index, item ->
+    StaggeredAnimatedFloatingActionButton(
+      expanded = expanded,
+      index = index,
+      fabItem = item,
+      onDismiss = onDismiss,
+    )
+  }
+}
+
+@Composable
+fun StaggeredAnimatedFloatingActionButton(
+  expanded: Boolean,
+  fabItem: FloatingActionButtonItem,
+  index: Int,
+  onDismiss: () -> Unit,
+) {
+  val enterTransition = remember {
+    fadeIn(animationSpec = tween(durationMillis = 200, delayMillis = index * 50)) +
+      slideInVertically(
+        animationSpec = tween(
+          durationMillis = 200,
+          delayMillis = index * 50,
+        ),
+      ) { fullHeight -> fullHeight }
+  }
+  val exitTransition = remember {
+    fadeOut(animationSpec = tween(durationMillis = 200)) +
+      slideOutVertically(animationSpec = tween(durationMillis = 200)) { fullHeight -> fullHeight }
+  }
+
+  AnimatedVisibility(
+    visible = expanded,
+    enter = enterTransition,
+    exit = exitTransition,
+  ) {
+    Row(
+      verticalAlignment = Alignment.CenterVertically,
+      horizontalArrangement = Arrangement.spacedBy(MaterialTheme.dimensions.keyline_8),
+      modifier = Modifier
+        .padding(bottom = MaterialTheme.dimensions.keyline_16)
+        .clickable(
+          interactionSource = null,
+          indication = null,
+          onClick = {
+            onDismiss()
+            fabItem.onClick
+          },
+        ),
+    ) {
+      Text(
+        text = fabItem.label,
+        color = MaterialTheme.colorScheme.onSurface,
+        style = MaterialTheme.typography.titleSmall,
+        modifier = Modifier.padding(start = MaterialTheme.dimensions.keyline_8),
+      )
+      SmallFloatingActionButton(
+        onClick = {
+          onDismiss()
+          fabItem.onClick
+        },
+      ) {
+        Icon(fabItem.icon, contentDescription = fabItem.contentDescription)
+      }
+    }
+  }
+}
+
+@Previews
+@Composable
+fun ExpandableFloatingActionButton() {
+  AppTheme {
+    Surface {
+      Text(
+        text = "Click the FAB to expand",
+        style = MaterialTheme.typography.headlineLarge,
+        modifier = Modifier.padding(MaterialTheme.dimensions.keyline_16),
+      )
+
+      ExpandableFloatActionButton(
+        buttons = listOf(
+          FloatingActionButtonItem(
+            icon = Icons.Filled.Brush,
+            label = "Brush",
+            contentDescription = "Add",
+            onClick = {},
+          ),
+          FloatingActionButtonItem(
+            icon = Icons.Filled.Adb,
+            label = "Adb",
+            contentDescription = "Add",
+            onClick = {},
+          ),
+          FloatingActionButtonItem(
+            icon = Icons.Filled.Call,
+            label = "Call",
+            contentDescription = "Add",
+            onClick = {},
+          ),
+        ),
+      )
+    }
+  }
+}

--- a/core/ui/src/main/kotlin/com/divinelink/core/ui/components/expandablefab/ExpandableFloatingActionButton.kt
+++ b/core/ui/src/main/kotlin/com/divinelink/core/ui/components/expandablefab/ExpandableFloatingActionButton.kt
@@ -10,6 +10,7 @@ import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -22,9 +23,9 @@ import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Adb
-import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Brush
 import androidx.compose.material.icons.filled.Call
+import androidx.compose.material.icons.rounded.Add
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -39,10 +40,12 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.rotate
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.zIndex
 import com.divinelink.core.designsystem.theme.AppTheme
 import com.divinelink.core.designsystem.theme.dimensions
+import com.divinelink.core.ui.IconWrapper
 import com.divinelink.core.ui.Previews
 import com.divinelink.core.ui.UIText
 import com.divinelink.core.ui.getString
@@ -120,7 +123,7 @@ fun ExpandableFloatActionButton(
         onClick = { expanded = !expanded },
         modifier = Modifier.rotate(rotationState),
       ) {
-        Icon(Icons.Filled.Add, contentDescription = "Expandable FAB")
+        Icon(Icons.Rounded.Add, contentDescription = "Expandable FAB")
       }
     }
   }
@@ -194,10 +197,20 @@ fun StaggeredAnimatedFloatingActionButton(
           onDismiss()
         },
       ) {
-        Icon(
-          imageVector = fabItem.icon,
-          contentDescription = fabItem.contentDescription.getString(),
-        )
+        when (fabItem.icon) {
+          is IconWrapper.Image -> Image(
+            painter = painterResource(id = fabItem.icon.resourceId),
+            contentDescription = fabItem.contentDescription.getString(),
+          )
+          is IconWrapper.Icon -> Icon(
+            painter = painterResource(id = fabItem.icon.resourceId),
+            contentDescription = fabItem.contentDescription.getString(),
+          )
+          is IconWrapper.Vector -> Icon(
+            imageVector = fabItem.icon.vector,
+            contentDescription = fabItem.contentDescription.getString(),
+          )
+        }
       }
     }
   }
@@ -217,19 +230,19 @@ private fun ExpandableFloatingActionButton() {
       ExpandableFloatActionButton(
         buttons = listOf(
           FloatingActionButtonItem(
-            icon = Icons.Filled.Brush,
+            icon = IconWrapper.Vector(Icons.Filled.Brush),
             label = UIText.StringText("Brush"),
             contentDescription = UIText.StringText("Add"),
             onClick = {},
           ),
           FloatingActionButtonItem(
-            icon = Icons.Filled.Adb,
+            icon = IconWrapper.Vector(Icons.Filled.Adb),
             label = UIText.StringText("Adb"),
             contentDescription = UIText.StringText("Add"),
             onClick = {},
           ),
           FloatingActionButtonItem(
-            icon = Icons.Filled.Call,
+            icon = IconWrapper.Vector(Icons.Filled.Call),
             label = UIText.StringText("Call"),
             contentDescription = UIText.StringText("Add"),
             onClick = {},

--- a/core/ui/src/main/kotlin/com/divinelink/core/ui/components/expandablefab/ExpandableFloatingActionButton.kt
+++ b/core/ui/src/main/kotlin/com/divinelink/core/ui/components/expandablefab/ExpandableFloatingActionButton.kt
@@ -30,19 +30,20 @@ import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.SmallFloatingActionButton
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.IntOffset
-import androidx.compose.ui.zIndex
 import com.divinelink.core.designsystem.theme.AppTheme
 import com.divinelink.core.designsystem.theme.dimensions
 import com.divinelink.core.ui.IconWrapper
@@ -50,6 +51,7 @@ import com.divinelink.core.ui.Previews
 import com.divinelink.core.ui.UIText
 import com.divinelink.core.ui.getString
 import com.divinelink.core.ui.snackbar.controller.LocalSnackbarController
+import com.divinelink.core.ui.snackbar.controller.ProvideSnackbarController
 
 @Composable
 fun ExpandableFloatActionButton(
@@ -82,7 +84,6 @@ fun ExpandableFloatActionButton(
     AnimatedVisibility(
       modifier = Modifier
         .fillMaxSize()
-        .zIndex(1f)
         .offset(
           x = MaterialTheme.dimensions.keyline_16,
           y = MaterialTheme.dimensions.keyline_16,
@@ -107,7 +108,6 @@ fun ExpandableFloatActionButton(
       horizontalAlignment = Alignment.End,
       verticalArrangement = Arrangement.Bottom,
       modifier = Modifier
-        .zIndex(2f)
         .offset { IntOffset(0, -fabOffset.roundToPx()) }
         .fillMaxSize(),
     ) {
@@ -219,36 +219,44 @@ fun StaggeredAnimatedFloatingActionButton(
 @Previews
 @Composable
 private fun ExpandableFloatingActionButton() {
-  AppTheme {
-    Surface {
-      Text(
-        text = "Click the FAB to expand",
-        style = MaterialTheme.typography.headlineLarge,
-        modifier = Modifier.padding(MaterialTheme.dimensions.keyline_16),
-      )
+  val snackbarHostState = remember { SnackbarHostState() }
+  val coroutineScope = rememberCoroutineScope()
 
-      ExpandableFloatActionButton(
-        buttons = listOf(
-          FloatingActionButtonItem(
-            icon = IconWrapper.Vector(Icons.Filled.Brush),
-            label = UIText.StringText("Brush"),
-            contentDescription = UIText.StringText("Add"),
-            onClick = {},
+  ProvideSnackbarController(
+    snackbarHostState = snackbarHostState,
+    coroutineScope = coroutineScope,
+  ) {
+    AppTheme {
+      Surface {
+        Text(
+          text = "Click the FAB to expand",
+          style = MaterialTheme.typography.headlineLarge,
+          modifier = Modifier.padding(MaterialTheme.dimensions.keyline_16),
+        )
+
+        ExpandableFloatActionButton(
+          buttons = listOf(
+            FloatingActionButtonItem(
+              icon = IconWrapper.Vector(Icons.Filled.Brush),
+              label = UIText.StringText("Brush"),
+              contentDescription = UIText.StringText("Add"),
+              onClick = {},
+            ),
+            FloatingActionButtonItem(
+              icon = IconWrapper.Vector(Icons.Filled.Adb),
+              label = UIText.StringText("Adb"),
+              contentDescription = UIText.StringText("Add"),
+              onClick = {},
+            ),
+            FloatingActionButtonItem(
+              icon = IconWrapper.Vector(Icons.Filled.Call),
+              label = UIText.StringText("Call"),
+              contentDescription = UIText.StringText("Add"),
+              onClick = {},
+            ),
           ),
-          FloatingActionButtonItem(
-            icon = IconWrapper.Vector(Icons.Filled.Adb),
-            label = UIText.StringText("Adb"),
-            contentDescription = UIText.StringText("Add"),
-            onClick = {},
-          ),
-          FloatingActionButtonItem(
-            icon = IconWrapper.Vector(Icons.Filled.Call),
-            label = UIText.StringText("Call"),
-            contentDescription = UIText.StringText("Add"),
-            onClick = {},
-          ),
-        ),
-      )
+        )
+      }
     }
   }
 }

--- a/core/ui/src/main/kotlin/com/divinelink/core/ui/components/expandablefab/ExpandableFloatingActionButton.kt
+++ b/core/ui/src/main/kotlin/com/divinelink/core/ui/components/expandablefab/ExpandableFloatingActionButton.kt
@@ -1,7 +1,10 @@
 package com.divinelink.core.ui.components.expandablefab
 
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.spring
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
@@ -15,6 +18,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Adb
@@ -35,30 +39,64 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.rotate
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.zIndex
 import com.divinelink.core.designsystem.theme.AppTheme
 import com.divinelink.core.designsystem.theme.dimensions
 import com.divinelink.core.ui.Previews
+import com.divinelink.core.ui.UIText
+import com.divinelink.core.ui.getString
+import com.divinelink.core.ui.snackbar.controller.LocalSnackbarController
 
 @Composable
-fun ExpandableFloatActionButton(buttons: List<FloatingActionButtonItem>) {
+fun ExpandableFloatActionButton(
+  modifier: Modifier = Modifier,
+  buttons: List<FloatingActionButtonItem>,
+) {
+  val snackbarController = LocalSnackbarController.current
+
   var expanded by remember { mutableStateOf(false) }
   val rotationState by animateFloatAsState(
     targetValue = if (expanded) 45f else 0f,
     animationSpec = tween(durationMillis = 300),
-    label = "FAB Rotation Animation",
+    label = "Floating Action Button Rotation Animation",
   )
 
-  Box(modifier = Modifier.fillMaxSize()) {
+  val fabOffset by animateDpAsState(
+    targetValue = if (snackbarController.isVisible()) {
+      MaterialTheme.dimensions.keyline_58
+    } else {
+      MaterialTheme.dimensions.keyline_0
+    },
+    animationSpec = spring(
+      dampingRatio = Spring.DampingRatioMediumBouncy,
+      stiffness = Spring.StiffnessLow,
+    ),
+    label = "Snackbar Offset Animation",
+  )
+
+  Box(modifier = modifier.fillMaxSize()) {
     AnimatedVisibility(
+      modifier = Modifier
+        .fillMaxSize()
+        .zIndex(1f)
+        .offset(
+          x = MaterialTheme.dimensions.keyline_16,
+          y = MaterialTheme.dimensions.keyline_16,
+        ),
       visible = expanded,
       enter = fadeIn(animationSpec = tween(durationMillis = 300)),
       exit = fadeOut(animationSpec = tween(durationMillis = 300)),
     ) {
       Box(
         modifier = Modifier
-          .fillMaxSize()
           .background(MaterialTheme.colorScheme.surface.copy(alpha = 0.9f))
-          .clickable { expanded = false },
+          .fillMaxSize()
+          .clickable(
+            interactionSource = null,
+            indication = null,
+            onClick = { expanded = false },
+          ),
       )
     }
 
@@ -66,8 +104,9 @@ fun ExpandableFloatActionButton(buttons: List<FloatingActionButtonItem>) {
       horizontalAlignment = Alignment.End,
       verticalArrangement = Arrangement.Bottom,
       modifier = Modifier
-        .fillMaxSize()
-        .padding(MaterialTheme.dimensions.keyline_16),
+        .zIndex(2f)
+        .offset { IntOffset(0, -fabOffset.roundToPx()) }
+        .fillMaxSize(),
     ) {
       StaggeredFloatingActionsButtons(
         fabItems = buttons,
@@ -138,24 +177,27 @@ fun StaggeredAnimatedFloatingActionButton(
           interactionSource = null,
           indication = null,
           onClick = {
+            fabItem.onClick()
             onDismiss()
-            fabItem.onClick
           },
         ),
     ) {
       Text(
-        text = fabItem.label,
+        text = fabItem.label.getString(),
         color = MaterialTheme.colorScheme.onSurface,
         style = MaterialTheme.typography.titleSmall,
         modifier = Modifier.padding(start = MaterialTheme.dimensions.keyline_8),
       )
       SmallFloatingActionButton(
         onClick = {
+          fabItem.onClick()
           onDismiss()
-          fabItem.onClick
         },
       ) {
-        Icon(fabItem.icon, contentDescription = fabItem.contentDescription)
+        Icon(
+          imageVector = fabItem.icon,
+          contentDescription = fabItem.contentDescription.getString(),
+        )
       }
     }
   }
@@ -163,7 +205,7 @@ fun StaggeredAnimatedFloatingActionButton(
 
 @Previews
 @Composable
-fun ExpandableFloatingActionButton() {
+private fun ExpandableFloatingActionButton() {
   AppTheme {
     Surface {
       Text(
@@ -176,20 +218,20 @@ fun ExpandableFloatingActionButton() {
         buttons = listOf(
           FloatingActionButtonItem(
             icon = Icons.Filled.Brush,
-            label = "Brush",
-            contentDescription = "Add",
+            label = UIText.StringText("Brush"),
+            contentDescription = UIText.StringText("Add"),
             onClick = {},
           ),
           FloatingActionButtonItem(
             icon = Icons.Filled.Adb,
-            label = "Adb",
-            contentDescription = "Add",
+            label = UIText.StringText("Adb"),
+            contentDescription = UIText.StringText("Add"),
             onClick = {},
           ),
           FloatingActionButtonItem(
             icon = Icons.Filled.Call,
-            label = "Call",
-            contentDescription = "Add",
+            label = UIText.StringText("Call"),
+            contentDescription = UIText.StringText("Add"),
             onClick = {},
           ),
         ),

--- a/core/ui/src/main/kotlin/com/divinelink/core/ui/components/expandablefab/ExpandableFloatingActionButton.kt
+++ b/core/ui/src/main/kotlin/com/divinelink/core/ui/components/expandablefab/ExpandableFloatingActionButton.kt
@@ -42,12 +42,14 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.rotate
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.IntOffset
 import com.divinelink.core.designsystem.theme.AppTheme
 import com.divinelink.core.designsystem.theme.dimensions
 import com.divinelink.core.ui.IconWrapper
 import com.divinelink.core.ui.Previews
+import com.divinelink.core.ui.TestTags
 import com.divinelink.core.ui.UIText
 import com.divinelink.core.ui.getString
 import com.divinelink.core.ui.snackbar.controller.LocalSnackbarController
@@ -95,6 +97,7 @@ fun ExpandableFloatActionButton(
       Box(
         modifier = Modifier
           .background(MaterialTheme.colorScheme.surface.copy(alpha = 0.9f))
+          .testTag(TestTags.Components.ExpandableFab.BACKGROUND)
           .fillMaxSize()
           .clickable(
             interactionSource = null,
@@ -121,9 +124,14 @@ fun ExpandableFloatActionButton(
 
       FloatingActionButton(
         onClick = { expanded = !expanded },
-        modifier = Modifier.rotate(rotationState),
+        modifier = Modifier
+          .testTag(TestTags.Components.ExpandableFab.BUTTON)
+          .rotate(rotationState),
       ) {
-        Icon(Icons.Rounded.Add, contentDescription = "Expandable FAB")
+        Icon(
+          imageVector = Icons.Rounded.Add,
+          contentDescription = "Expandable FAB",
+        )
       }
     }
   }

--- a/core/ui/src/main/kotlin/com/divinelink/core/ui/components/expandablefab/FloatingActionButtonItem.kt
+++ b/core/ui/src/main/kotlin/com/divinelink/core/ui/components/expandablefab/FloatingActionButtonItem.kt
@@ -1,0 +1,10 @@
+package com.divinelink.core.ui.components.expandablefab
+
+import androidx.compose.ui.graphics.vector.ImageVector
+
+data class FloatingActionButtonItem(
+  val icon: ImageVector,
+  val label: String,
+  val contentDescription: String,
+  val onClick: () -> Unit,
+)

--- a/core/ui/src/main/kotlin/com/divinelink/core/ui/components/expandablefab/FloatingActionButtonItem.kt
+++ b/core/ui/src/main/kotlin/com/divinelink/core/ui/components/expandablefab/FloatingActionButtonItem.kt
@@ -1,10 +1,11 @@
 package com.divinelink.core.ui.components.expandablefab
 
 import androidx.compose.ui.graphics.vector.ImageVector
+import com.divinelink.core.ui.UIText
 
-data class FloatingActionButtonItem(
+open class FloatingActionButtonItem(
   val icon: ImageVector,
-  val label: String,
-  val contentDescription: String,
+  val label: UIText,
+  val contentDescription: UIText,
   val onClick: () -> Unit,
 )

--- a/core/ui/src/main/kotlin/com/divinelink/core/ui/components/expandablefab/FloatingActionButtonItem.kt
+++ b/core/ui/src/main/kotlin/com/divinelink/core/ui/components/expandablefab/FloatingActionButtonItem.kt
@@ -1,10 +1,10 @@
 package com.divinelink.core.ui.components.expandablefab
 
-import androidx.compose.ui.graphics.vector.ImageVector
+import com.divinelink.core.ui.IconWrapper
 import com.divinelink.core.ui.UIText
 
 open class FloatingActionButtonItem(
-  val icon: ImageVector,
+  val icon: IconWrapper,
   val label: UIText,
   val contentDescription: UIText,
   val onClick: () -> Unit,

--- a/core/ui/src/main/kotlin/com/divinelink/core/ui/extension/StringExtension.kt
+++ b/core/ui/src/main/kotlin/com/divinelink/core/ui/extension/StringExtension.kt
@@ -1,10 +1,13 @@
 package com.divinelink.core.ui.extension
 
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
 
+@Composable
 fun String.getColorRating(): Color = when (toDouble()) {
   in 0.1..3.5 -> Color(0xFFDB2360)
   in 3.5..6.99 -> Color(0xFFD2D531)
   in 7.0..10.0 -> Color(0xFF21D07A)
-  else -> Color.White
+  else -> MaterialTheme.colorScheme.onSurface
 }

--- a/core/ui/src/main/kotlin/com/divinelink/core/ui/snackbar/controller/SnackbarController.kt
+++ b/core/ui/src/main/kotlin/com/divinelink/core/ui/snackbar/controller/SnackbarController.kt
@@ -22,6 +22,8 @@ interface SnackbarController {
     snackbarVisuals: SnackbarVisuals,
     onSnackbarResult: (SnackbarResult) -> Unit = {},
   )
+
+  fun isVisible(): Boolean
 }
 
 @Stable

--- a/core/ui/src/main/kotlin/com/divinelink/core/ui/snackbar/controller/SnackbarControllerImpl.kt
+++ b/core/ui/src/main/kotlin/com/divinelink/core/ui/snackbar/controller/SnackbarControllerImpl.kt
@@ -38,4 +38,6 @@ class SnackbarControllerImpl(
       snackbarHostState.showSnackbar(visuals = snackbarVisuals).let(onSnackbarResult)
     }
   }
+
+  override fun isVisible(): Boolean = snackbarHostState.currentSnackbarData != null
 }

--- a/core/ui/src/main/res/drawable/core_ui_ic_female_person_placeholder.xml
+++ b/core/ui/src/main/res/drawable/core_ui_ic_female_person_placeholder.xml
@@ -1,16 +1,16 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
     android:width="200dp"
     android:height="200dp"
-    android:tint="@color/colorSurface_60"
+    android:tint="@color/colorSurfaceVariant"
     android:viewportWidth="24"
     android:viewportHeight="24">
 
   <path
-      android:fillColor="@color/colorSurface_60"
+      android:fillColor="@color/colorSurfaceVariant"
       android:pathData="M18.39,14.56C16.71,13.7 14.53,13 12,13c-2.53,0 -4.71,0.7 -6.39,1.56C4.61,15.07 4,16.1 4,17.22V20h16v-2.78C20,16.1 19.39,15.07 18.39,14.56z" />
 
   <path
-      android:fillColor="@color/colorSurface_60"
+      android:fillColor="@color/colorSurfaceVariant"
       android:pathData="M10,12c0.17,0 3.83,0 4,0c1.66,0 3,-1.34 3,-3c0,-0.73 -0.27,-1.4 -0.71,-1.92C16.42,6.75 16.5,6.38 16.5,6c0,-1.25 -0.77,-2.32 -1.86,-2.77C14,2.48 13.06,2 12,2s-2,0.48 -2.64,1.23C8.27,3.68 7.5,4.75 7.5,6c0,0.38 0.08,0.75 0.21,1.08C7.27,7.6 7,8.27 7,9C7,10.66 8.34,12 10,12z" />
 
 </vector>

--- a/core/ui/src/main/res/drawable/core_ui_ic_movie_placeholder.xml
+++ b/core/ui/src/main/res/drawable/core_ui_ic_movie_placeholder.xml
@@ -1,10 +1,10 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
     android:width="160dp"
     android:height="160dp"
-    android:tint="@color/colorSurface_60"
+    android:tint="@color/colorSurfaceVariant"
     android:viewportWidth="24"
     android:viewportHeight="24">
   <path
-      android:fillColor="@color/colorSurface_60"
+      android:fillColor="@color/colorSurfaceVariant"
       android:pathData="M18,3v2h-2L16,3L8,3v2L6,5L6,3L4,3v18h2v-2h2v2h8v-2h2v2h2L20,3h-2zM8,17L6,17v-2h2v2zM8,13L6,13v-2h2v2zM8,9L6,9L6,7h2v2zM18,17h-2v-2h2v2zM18,13h-2v-2h2v2zM18,9h-2L16,7h2v2z" />
 </vector>

--- a/core/ui/src/main/res/drawable/core_ui_ic_person_placeholder.xml
+++ b/core/ui/src/main/res/drawable/core_ui_ic_person_placeholder.xml
@@ -1,10 +1,10 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
     android:width="200dp"
     android:height="200dp"
-    android:tint="@color/colorSurface_60"
+    android:tint="@color/colorSurfaceVariant"
     android:viewportWidth="24"
     android:viewportHeight="24">
   <path
-      android:fillColor="@color/colorSurface_60"
+      android:fillColor="@color/colorSurfaceVariant"
       android:pathData="M12,12c2.21,0 4,-1.79 4,-4s-1.79,-4 -4,-4 -4,1.79 -4,4 1.79,4 4,4zM12,14c-2.67,0 -8,1.34 -8,4v2h16v-2c0,-2.66 -5.33,-4 -8,-4z" />
 </vector>

--- a/core/ui/src/test/kotlin/com/divinelink/core/ui/DetailsDropDownMenuTest.kt
+++ b/core/ui/src/test/kotlin/com/divinelink/core/ui/DetailsDropDownMenuTest.kt
@@ -2,7 +2,6 @@ package com.divinelink.core.ui
 
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.onNodeWithTag
-import androidx.compose.ui.test.performClick
 import com.divinelink.core.model.details.DetailsMenuOptions
 import com.divinelink.core.testing.ComposeTest
 import com.divinelink.core.testing.factories.model.details.MediaDetailsFactory
@@ -16,9 +15,8 @@ class DetailsDropDownMenuTest : ComposeTest() {
     composeTestRule.setContent {
       DetailsDropdownMenu(
         mediaDetails = MediaDetailsFactory.FightClub(),
-        menuOptions = listOf(DetailsMenuOptions.SHARE),
         expanded = true,
-        requestMedia = {},
+        options = listOf(DetailsMenuOptions.SHARE),
         onDismissDropdown = {},
       )
     }
@@ -28,64 +26,43 @@ class DetailsDropDownMenuTest : ComposeTest() {
     ).assertIsDisplayed()
   }
 
-  @Test
-  fun `test show details drop down menu with share and request options`() {
-    composeTestRule.setContent {
-      DetailsDropdownMenu(
-        mediaDetails = MediaDetailsFactory.FightClub(),
-        menuOptions = listOf(DetailsMenuOptions.SHARE, DetailsMenuOptions.REQUEST),
-        expanded = true,
-        requestMedia = {},
-        onDismissDropdown = {},
-      )
-    }
+//  @Test
+//  fun `test open request dialog for tv show`() {
+//    composeTestRule.setContent {
+//      DetailsDropdownMenu(
+//        mediaDetails = MediaDetailsFactory.TheOffice(),
+//        menuOptions = listOf(DetailsMenuOptions.SHARE, DetailsMenuOptions.REQUEST),
+//        expanded = true,
+//        requestMedia = {},
+//        onDismissDropdown = {},
+//      )
+//    }
+//    composeTestRule.onNodeWithTag(
+//      TestTags.Menu.MENU_ITEM.format(getString(R.string.core_ui_dropdown_menu_request)),
+//    )
+//      .assertIsDisplayed()
+//      .performClick()
+//
+//    composeTestRule.onNodeWithTag(TestTags.Dialogs.SELECT_SEASONS_DIALOG).assertIsDisplayed()
+//  }
 
-    composeTestRule.onNodeWithTag(
-      TestTags.Menu.MENU_ITEM.format(getString(R.string.core_ui_share)),
-    ).assertIsDisplayed()
-
-    composeTestRule.onNodeWithTag(
-      TestTags.Menu.MENU_ITEM.format(getString(R.string.core_ui_dropdown_menu_request)),
-    ).assertIsDisplayed()
-  }
-
-  @Test
-  fun `test open request dialog for tv show`() {
-    composeTestRule.setContent {
-      DetailsDropdownMenu(
-        mediaDetails = MediaDetailsFactory.TheOffice(),
-        menuOptions = listOf(DetailsMenuOptions.SHARE, DetailsMenuOptions.REQUEST),
-        expanded = true,
-        requestMedia = {},
-        onDismissDropdown = {},
-      )
-    }
-    composeTestRule.onNodeWithTag(
-      TestTags.Menu.MENU_ITEM.format(getString(R.string.core_ui_dropdown_menu_request)),
-    )
-      .assertIsDisplayed()
-      .performClick()
-
-    composeTestRule.onNodeWithTag(TestTags.Dialogs.SELECT_SEASONS_DIALOG).assertIsDisplayed()
-  }
-
-  @Test
-  fun `test open request dialog for movie`() {
-    composeTestRule.setContent {
-      DetailsDropdownMenu(
-        mediaDetails = MediaDetailsFactory.FightClub(),
-        menuOptions = listOf(DetailsMenuOptions.SHARE, DetailsMenuOptions.REQUEST),
-        expanded = true,
-        requestMedia = {},
-        onDismissDropdown = {},
-      )
-    }
-    composeTestRule.onNodeWithTag(
-      TestTags.Menu.MENU_ITEM.format(getString(R.string.core_ui_dropdown_menu_request)),
-    )
-      .assertIsDisplayed()
-      .performClick()
-
-    composeTestRule.onNodeWithTag(TestTags.Dialogs.REQUEST_MOVIE_DIALOG).assertIsDisplayed()
-  }
+//  @Test
+//  fun `test open request dialog for movie`() {
+//    composeTestRule.setContent {
+//      DetailsDropdownMenu(
+//        mediaDetails = MediaDetailsFactory.FightClub(),
+//        menuOptions = listOf(DetailsMenuOptions.SHARE, DetailsMenuOptions.REQUEST),
+//        expanded = true,
+//        requestMedia = {},
+//        onDismissDropdown = {},
+//      )
+//    }
+//    composeTestRule.onNodeWithTag(
+//      TestTags.Menu.MENU_ITEM.format(getString(R.string.core_ui_dropdown_menu_request)),
+//    )
+//      .assertIsDisplayed()
+//      .performClick()
+//
+//    composeTestRule.onNodeWithTag(TestTags.Dialogs.REQUEST_MOVIE_DIALOG).assertIsDisplayed()
+//  }
 }

--- a/core/ui/src/test/kotlin/com/divinelink/core/ui/DetailsDropDownMenuTest.kt
+++ b/core/ui/src/test/kotlin/com/divinelink/core/ui/DetailsDropDownMenuTest.kt
@@ -25,44 +25,4 @@ class DetailsDropDownMenuTest : ComposeTest() {
       TestTags.Menu.MENU_ITEM.format(getString(R.string.core_ui_share)),
     ).assertIsDisplayed()
   }
-
-//  @Test
-//  fun `test open request dialog for tv show`() {
-//    composeTestRule.setContent {
-//      DetailsDropdownMenu(
-//        mediaDetails = MediaDetailsFactory.TheOffice(),
-//        menuOptions = listOf(DetailsMenuOptions.SHARE, DetailsMenuOptions.REQUEST),
-//        expanded = true,
-//        requestMedia = {},
-//        onDismissDropdown = {},
-//      )
-//    }
-//    composeTestRule.onNodeWithTag(
-//      TestTags.Menu.MENU_ITEM.format(getString(R.string.core_ui_dropdown_menu_request)),
-//    )
-//      .assertIsDisplayed()
-//      .performClick()
-//
-//    composeTestRule.onNodeWithTag(TestTags.Dialogs.SELECT_SEASONS_DIALOG).assertIsDisplayed()
-//  }
-
-//  @Test
-//  fun `test open request dialog for movie`() {
-//    composeTestRule.setContent {
-//      DetailsDropdownMenu(
-//        mediaDetails = MediaDetailsFactory.FightClub(),
-//        menuOptions = listOf(DetailsMenuOptions.SHARE, DetailsMenuOptions.REQUEST),
-//        expanded = true,
-//        requestMedia = {},
-//        onDismissDropdown = {},
-//      )
-//    }
-//    composeTestRule.onNodeWithTag(
-//      TestTags.Menu.MENU_ITEM.format(getString(R.string.core_ui_dropdown_menu_request)),
-//    )
-//      .assertIsDisplayed()
-//      .performClick()
-//
-//    composeTestRule.onNodeWithTag(TestTags.Dialogs.REQUEST_MOVIE_DIALOG).assertIsDisplayed()
-//  }
 }

--- a/core/ui/src/test/kotlin/com/divinelink/core/ui/components/expandablefab/ExpandableFloatingActionButtonTest.kt
+++ b/core/ui/src/test/kotlin/com/divinelink/core/ui/components/expandablefab/ExpandableFloatingActionButtonTest.kt
@@ -1,0 +1,168 @@
+package com.divinelink.core.ui.components.expandablefab
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.Add
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsNotDisplayed
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import com.divinelink.core.testing.ComposeTest
+import com.divinelink.core.testing.setContentWithTheme
+import com.divinelink.core.ui.IconWrapper
+import com.divinelink.core.ui.R
+import com.divinelink.core.ui.TestTags
+import com.divinelink.core.ui.UIText
+import com.google.common.truth.Truth.assertThat
+import kotlin.test.Test
+
+class ExpandableFloatingActionButtonTest : ComposeTest() {
+
+  @Test
+  fun `test buttons are shown when fab button is clicked`() {
+    var extraActionIsClicked = false
+
+    val actionButtons = listOf(
+      FloatingActionButtonItem(
+        icon = IconWrapper.Vector(Icons.Rounded.Add),
+        label = UIText.StringText("Add"),
+        contentDescription = UIText.StringText("Add Button"),
+        onClick = { extraActionIsClicked = true },
+      ),
+      FloatingActionButtonItem(
+        icon = IconWrapper.Image(R.drawable.core_ui_ic_jellyseerr),
+        label = UIText.StringText("Delete"),
+        contentDescription = UIText.StringText("Delete Button"),
+        onClick = { extraActionIsClicked = true },
+      ),
+      FloatingActionButtonItem(
+        icon = IconWrapper.Icon(R.drawable.core_ui_ic_error_64),
+        label = UIText.StringText("Close"),
+        contentDescription = UIText.StringText("Close Button"),
+        onClick = { extraActionIsClicked = true },
+      ),
+    )
+
+    setContentWithTheme {
+      ExpandableFloatActionButton(
+        buttons = actionButtons,
+      )
+    }
+
+    with(composeTestRule) {
+      onNodeWithTag(TestTags.Components.ExpandableFab.BUTTON).assertIsDisplayed()
+      onNodeWithContentDescription("Add Button").assertIsNotDisplayed()
+      onNodeWithContentDescription("Delete Button").assertIsNotDisplayed()
+      onNodeWithContentDescription("Close Button").assertIsNotDisplayed()
+
+      onNodeWithTag(TestTags.Components.ExpandableFab.BUTTON).performClick()
+
+      onNodeWithContentDescription("Add Button").assertIsDisplayed()
+      onNodeWithContentDescription("Delete Button").assertIsDisplayed()
+      onNodeWithContentDescription("Close Button").assertIsDisplayed()
+
+      assertThat(extraActionIsClicked).isFalse()
+
+      onNodeWithContentDescription("Add Button").performClick()
+
+      onNodeWithTag(TestTags.Components.ExpandableFab.BUTTON).assertIsDisplayed()
+
+      onNodeWithContentDescription("Add Button").assertIsNotDisplayed()
+      onNodeWithContentDescription("Delete Button").assertIsNotDisplayed()
+      onNodeWithContentDescription("Close Button").assertIsNotDisplayed()
+      assertThat(extraActionIsClicked).isTrue()
+    }
+  }
+
+  @Test
+  fun `test icons are displayed`() {
+    val actionButtons = listOf(
+      FloatingActionButtonItem(
+        icon = IconWrapper.Vector(Icons.Rounded.Add),
+        label = UIText.StringText("Add"),
+        contentDescription = UIText.StringText("Add Button"),
+        onClick = { },
+      ),
+      FloatingActionButtonItem(
+        icon = IconWrapper.Image(R.drawable.core_ui_ic_jellyseerr),
+        label = UIText.StringText("Delete"),
+        contentDescription = UIText.StringText("Delete Button"),
+        onClick = { },
+      ),
+      FloatingActionButtonItem(
+        icon = IconWrapper.Icon(R.drawable.core_ui_ic_error_64),
+        label = UIText.StringText("Close"),
+        contentDescription = UIText.StringText("Close Button"),
+        onClick = { },
+      ),
+    )
+
+    setContentWithTheme {
+      ExpandableFloatActionButton(
+        buttons = actionButtons,
+      )
+    }
+
+    with(composeTestRule) {
+      onNodeWithTag(TestTags.Components.ExpandableFab.BUTTON).assertIsDisplayed()
+
+      onNodeWithContentDescription("Add Button").assertIsNotDisplayed()
+      onNodeWithContentDescription("Delete Button").assertIsNotDisplayed()
+      onNodeWithContentDescription("Close Button").assertIsNotDisplayed()
+
+      onNodeWithTag(TestTags.Components.ExpandableFab.BUTTON).performClick()
+
+      onNodeWithContentDescription("Add Button").assertIsDisplayed()
+      onNodeWithContentDescription("Delete Button").assertIsDisplayed()
+      onNodeWithContentDescription("Close Button").assertIsDisplayed()
+    }
+  }
+
+  @Test
+  fun `test clicking on background dismisses actions`() {
+    val actionButtons = listOf(
+      FloatingActionButtonItem(
+        icon = IconWrapper.Vector(Icons.Rounded.Add),
+        label = UIText.StringText("Add"),
+        contentDescription = UIText.StringText("Add Button"),
+        onClick = { },
+      ),
+      FloatingActionButtonItem(
+        icon = IconWrapper.Image(R.drawable.core_ui_ic_jellyseerr),
+        label = UIText.StringText("Delete"),
+        contentDescription = UIText.StringText("Delete Button"),
+        onClick = { },
+      ),
+      FloatingActionButtonItem(
+        icon = IconWrapper.Icon(R.drawable.core_ui_ic_error_64),
+        label = UIText.StringText("Close"),
+        contentDescription = UIText.StringText("Close Button"),
+        onClick = { },
+      ),
+    )
+
+    setContentWithTheme {
+      ExpandableFloatActionButton(
+        buttons = actionButtons,
+      )
+    }
+
+    with(composeTestRule) {
+      onNodeWithTag(TestTags.Components.ExpandableFab.BUTTON).assertIsDisplayed()
+      onNodeWithContentDescription("Add Button").assertIsNotDisplayed()
+      onNodeWithContentDescription("Delete Button").assertIsNotDisplayed()
+      onNodeWithContentDescription("Close Button").assertIsNotDisplayed()
+
+      onNodeWithTag(TestTags.Components.ExpandableFab.BUTTON).performClick()
+
+      onNodeWithContentDescription("Add Button").assertIsDisplayed()
+      onNodeWithContentDescription("Delete Button").assertIsDisplayed()
+      onNodeWithContentDescription("Close Button").assertIsDisplayed()
+
+      onNodeWithTag(TestTags.Components.ExpandableFab.BACKGROUND).performClick()
+      onNodeWithContentDescription("Add Button").assertIsNotDisplayed()
+      onNodeWithContentDescription("Delete Button").assertIsNotDisplayed()
+      onNodeWithContentDescription("Close Button").assertIsNotDisplayed()
+    }
+  }
+}

--- a/feature/details/src/main/kotlin/com/divinelink/feature/details/media/ui/DetailsContent.kt
+++ b/feature/details/src/main/kotlin/com/divinelink/feature/details/media/ui/DetailsContent.kt
@@ -117,7 +117,7 @@ fun DetailsContent(
 
   SnackbarMessageHandler(
     snackbarMessage = viewState.snackbarMessage,
-    onDismissSnackbar = { onConsumeSnackbar() },
+    onDismissSnackbar = onConsumeSnackbar,
   )
 
   var showRequestDialog by remember { mutableStateOf(false) }

--- a/feature/details/src/main/kotlin/com/divinelink/feature/details/media/ui/DetailsContent.kt
+++ b/feature/details/src/main/kotlin/com/divinelink/feature/details/media/ui/DetailsContent.kt
@@ -20,9 +20,6 @@ import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.rounded.ArrowBack
-import androidx.compose.material.icons.filled.Download
-import androidx.compose.material.icons.filled.StarRate
-import androidx.compose.material.icons.filled.WatchLater
 import androidx.compose.material.icons.outlined.MoreVert
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
@@ -61,7 +58,6 @@ import com.divinelink.core.designsystem.theme.dimensions
 import com.divinelink.core.designsystem.theme.shape
 import com.divinelink.core.model.account.AccountMediaDetails
 import com.divinelink.core.model.credits.PersonRole
-import com.divinelink.core.model.details.DetailActionItem
 import com.divinelink.core.model.details.MediaDetails
 import com.divinelink.core.model.details.Movie
 import com.divinelink.core.model.details.Person
@@ -94,8 +90,6 @@ import com.divinelink.core.ui.components.dialog.AlertDialogUiState
 import com.divinelink.core.ui.components.dialog.RequestMovieDialog
 import com.divinelink.core.ui.components.dialog.SelectSeasonsDialog
 import com.divinelink.core.ui.components.dialog.SimpleAlertDialog
-import com.divinelink.core.ui.components.expandablefab.ExpandableFloatActionButton
-import com.divinelink.core.ui.components.expandablefab.FloatingActionButtonItem
 import com.divinelink.core.ui.snackbar.SnackbarMessageHandler
 import com.divinelink.core.ui.snackbar.controller.ProvideSnackbarController
 import com.divinelink.feature.details.R
@@ -158,29 +152,11 @@ fun DetailsContent(
       .navigationBarsPadding()
       .nestedScroll(scrollBehavior.nestedScrollConnection),
     floatingActionButton = {
-      ExpandableFloatActionButton(
-        buttons = viewState.actionButtons.map { button ->
-          when (button) {
-            DetailActionItem.RATE -> FloatingActionButtonItem(
-              icon = Icons.Filled.StarRate,
-              label = UIText.ResourceText(R.string.details__add_rating),
-              contentDescription = UIText.ResourceText(R.string.details__add_rating),
-              onClick = onAddRateClicked,
-            )
-            DetailActionItem.WATCHLIST -> FloatingActionButtonItem(
-              icon = Icons.Filled.WatchLater,
-              label = UIText.StringText("Watchlist"),
-              contentDescription = UIText.StringText("Watchlist"),
-              onClick = onAddToWatchlistClicked,
-            )
-            DetailActionItem.REQUEST -> FloatingActionButtonItem(
-              icon = Icons.Filled.Download, // painterResource(id = R.drawable.core_ui_ic_jellyseerr),
-              label = UIText.ResourceText(R.string.feature_details_request),
-              contentDescription = UIText.ResourceText(R.string.feature_details_request),
-              onClick = { showRequestDialog = true },
-            )
-          }
-        },
+      DetailsExpandableFloatingActionButton(
+        actionButtons = viewState.actionButtons,
+        onAddRateClicked = onAddRateClicked,
+        onAddToWatchlistClicked = onAddToWatchlistClicked,
+        onRequestClicked = { showRequestDialog = true },
       )
     },
     topBar = {

--- a/feature/details/src/main/kotlin/com/divinelink/feature/details/media/ui/DetailsContent.kt
+++ b/feature/details/src/main/kotlin/com/divinelink/feature/details/media/ui/DetailsContent.kt
@@ -95,7 +95,6 @@ import com.divinelink.core.ui.snackbar.controller.ProvideSnackbarController
 import com.divinelink.feature.details.R
 import com.divinelink.core.ui.R as uiR
 
-const val MOVIE_DETAILS_SCROLLABLE_LIST_TAG = "MOVIE_DETAILS_LAZY_COLUMN_TAG"
 private const val MAX_WIDTH_FOR_LANDSCAPE_PLAYER = 0.55f
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -202,6 +201,7 @@ fun DetailsContent(
             DetailsDropdownMenu(
               mediaDetails = viewState.mediaDetails,
               expanded = showDropdownMenu,
+              options = viewState.menuOptions,
               onDismissDropdown = { showDropdownMenu = false },
             )
           }
@@ -300,7 +300,7 @@ fun MediaDetailsContent(
   Surface {
     LazyColumn(
       modifier = modifier
-        .testTag(MOVIE_DETAILS_SCROLLABLE_LIST_TAG)
+        .testTag(TestTags.Details.CONTENT_LIST)
         .fillMaxWidth(),
     ) {
       item {

--- a/feature/details/src/main/kotlin/com/divinelink/feature/details/media/ui/DetailsExpandableFloatingActionButton.kt
+++ b/feature/details/src/main/kotlin/com/divinelink/feature/details/media/ui/DetailsExpandableFloatingActionButton.kt
@@ -1,0 +1,46 @@
+package com.divinelink.feature.details.media.ui
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.StarRate
+import androidx.compose.material.icons.rounded.WatchLater
+import androidx.compose.runtime.Composable
+import com.divinelink.core.model.details.DetailActionItem
+import com.divinelink.core.ui.IconWrapper
+import com.divinelink.core.ui.UIText
+import com.divinelink.core.ui.components.expandablefab.ExpandableFloatActionButton
+import com.divinelink.core.ui.components.expandablefab.FloatingActionButtonItem
+import com.divinelink.feature.details.R
+import com.divinelink.core.ui.R as uiR
+
+@Composable
+internal fun DetailsExpandableFloatingActionButton(
+  actionButtons: List<DetailActionItem>,
+  onAddRateClicked: () -> Unit,
+  onAddToWatchlistClicked: () -> Unit,
+  onRequestClicked: () -> Unit,
+) {
+  ExpandableFloatActionButton(
+    buttons = actionButtons.map { button ->
+      when (button) {
+        DetailActionItem.RATE -> FloatingActionButtonItem(
+          icon = IconWrapper.Vector(Icons.Rounded.StarRate),
+          label = UIText.ResourceText(R.string.details__add_rating),
+          contentDescription = UIText.ResourceText(R.string.details__add_rating),
+          onClick = onAddRateClicked,
+        )
+        DetailActionItem.WATCHLIST -> FloatingActionButtonItem(
+          icon = IconWrapper.Vector(Icons.Rounded.WatchLater),
+          label = UIText.StringText("Watchlist"),
+          contentDescription = UIText.StringText("Watchlist"),
+          onClick = onAddToWatchlistClicked,
+        )
+        DetailActionItem.REQUEST -> FloatingActionButtonItem(
+          icon = IconWrapper.Image(uiR.drawable.core_ui_ic_jellyseerr),
+          label = UIText.ResourceText(R.string.feature_details_request),
+          contentDescription = UIText.ResourceText(R.string.feature_details_request),
+          onClick = onRequestClicked,
+        )
+      }
+    },
+  )
+}

--- a/feature/details/src/main/kotlin/com/divinelink/feature/details/media/ui/DetailsExpandableFloatingActionButton.kt
+++ b/feature/details/src/main/kotlin/com/divinelink/feature/details/media/ui/DetailsExpandableFloatingActionButton.kt
@@ -30,8 +30,8 @@ internal fun DetailsExpandableFloatingActionButton(
         )
         DetailActionItem.WATCHLIST -> FloatingActionButtonItem(
           icon = IconWrapper.Vector(Icons.Rounded.WatchLater),
-          label = UIText.StringText("Watchlist"),
-          contentDescription = UIText.StringText("Watchlist"),
+          label = UIText.ResourceText(R.string.feature_details__watchlist),
+          contentDescription = UIText.ResourceText(R.string.feature_details__watchlist),
           onClick = onAddToWatchlistClicked,
         )
         DetailActionItem.REQUEST -> FloatingActionButtonItem(

--- a/feature/details/src/main/kotlin/com/divinelink/feature/details/media/ui/DetailsViewModel.kt
+++ b/feature/details/src/main/kotlin/com/divinelink/feature/details/media/ui/DetailsViewModel.kt
@@ -128,6 +128,13 @@ class DetailsViewModel(
                 )
               }
 
+              is MediaDetailsResult.ActionButtonsSuccess -> {
+                val successData = (result.data as MediaDetailsResult.ActionButtonsSuccess)
+                viewState.copy(
+                  actionButtons = successData.actionButtons,
+                )
+              }
+
               is MediaDetailsResult.Failure.FatalError -> viewState.copy(
                 error = (result.data as MediaDetailsResult.Failure.FatalError).message,
                 isLoading = false,

--- a/feature/details/src/main/kotlin/com/divinelink/feature/details/media/ui/DetailsViewState.kt
+++ b/feature/details/src/main/kotlin/com/divinelink/feature/details/media/ui/DetailsViewState.kt
@@ -2,6 +2,7 @@ package com.divinelink.feature.details.media.ui
 
 import com.divinelink.core.model.account.AccountMediaDetails
 import com.divinelink.core.model.credits.AggregateCredits
+import com.divinelink.core.model.details.DetailActionItem
 import com.divinelink.core.model.details.DetailsMenuOptions
 import com.divinelink.core.model.details.MediaDetails
 import com.divinelink.core.model.details.Movie
@@ -28,6 +29,7 @@ data class DetailsViewState(
   val showRateDialog: Boolean = false,
   val navigateToLogin: Boolean? = null,
   val menuOptions: List<DetailsMenuOptions> = emptyList(),
+  val actionButtons: List<DetailActionItem> = emptyList(),
 ) {
   val mediaItem = when (mediaDetails) {
     is Movie -> MediaItem.Media.Movie(

--- a/feature/details/src/main/kotlin/com/divinelink/feature/details/media/ui/MediaDetailsResult.kt
+++ b/feature/details/src/main/kotlin/com/divinelink/feature/details/media/ui/MediaDetailsResult.kt
@@ -2,6 +2,7 @@ package com.divinelink.feature.details.media.ui
 
 import com.divinelink.core.model.account.AccountMediaDetails
 import com.divinelink.core.model.credits.AggregateCredits
+import com.divinelink.core.model.details.DetailActionItem
 import com.divinelink.core.model.details.DetailsMenuOptions
 import com.divinelink.core.model.details.MediaDetails
 import com.divinelink.core.model.details.Review
@@ -27,6 +28,9 @@ sealed class MediaDetailsResult {
   data class CreditsSuccess(val aggregateCredits: AggregateCredits) : MediaDetailsResult()
 
   data class MenuOptionsSuccess(val menuOptions: List<DetailsMenuOptions>) : MediaDetailsResult()
+
+  data class ActionButtonsSuccess(val actionButtons: List<DetailActionItem>) :
+    MediaDetailsResult()
 
   sealed class Failure(
     open val message: UIText = UIText.ResourceText(R.string.general_error_message),

--- a/feature/details/src/main/kotlin/com/divinelink/feature/details/media/ui/rate/RateDialogContent.kt
+++ b/feature/details/src/main/kotlin/com/divinelink/feature/details/media/ui/rate/RateDialogContent.kt
@@ -109,7 +109,7 @@ private fun BottomSheetRateContentWithoutClearPreview() {
   AppTheme {
     Surface {
       RateDialogContent(
-        value = 5f,
+        value = 0f,
         mediaTitle = "The Godfather",
         onRateChanged = {},
         onSubmitRate = {},

--- a/feature/details/src/main/kotlin/com/divinelink/feature/details/media/ui/rate/RateSlider.kt
+++ b/feature/details/src/main/kotlin/com/divinelink/feature/details/media/ui/rate/RateSlider.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Slider
 import androidx.compose.material3.SliderDefaults
+import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.remember
@@ -34,7 +35,7 @@ fun RateSlider(
       in 0.1f..3.5f -> Color(0xFFDB2360)
       in 3.5f..6.9f -> Color(0xFFD2D531)
       in 7.0f..10.0f -> Color(0xFF21D07A)
-      else -> Color.White
+      else -> MaterialTheme.colorScheme.onSurface
     },
     label = "Color Rating Slider",
   )
@@ -63,26 +64,28 @@ fun RateSlider(
 @Composable
 private fun RateSliderPreview() {
   AppTheme {
-    Column(verticalArrangement = Arrangement.spacedBy(MaterialTheme.dimensions.keyline_8)) {
-      RateSlider(
-        value = 0f,
-        onValueChange = {},
-      )
+    Surface {
+      Column(verticalArrangement = Arrangement.spacedBy(MaterialTheme.dimensions.keyline_8)) {
+        RateSlider(
+          value = 0f,
+          onValueChange = {},
+        )
 
-      RateSlider(
-        value = 1f,
-        onValueChange = {},
-      )
+        RateSlider(
+          value = 1f,
+          onValueChange = {},
+        )
 
-      RateSlider(
-        value = 5f,
-        onValueChange = {},
-      )
+        RateSlider(
+          value = 5f,
+          onValueChange = {},
+        )
 
-      RateSlider(
-        value = 8f,
-        onValueChange = {},
-      )
+        RateSlider(
+          value = 8f,
+          onValueChange = {},
+        )
+      }
     }
   }
 }

--- a/feature/details/src/main/res/values/strings.xml
+++ b/feature/details/src/main/res/values/strings.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+  <string name="feature_details__watchlist">Watchlist</string>
   <string name="details__user_score">User\nScore</string>
   <string name="details__your_rating">Your rating</string>
   <string name="details__add_rating">Rate this</string>

--- a/feature/settings/src/main/kotlin/com/divinelink/feature/settings/app/account/jellyseerr/JellyseerrSettingsScreen.kt
+++ b/feature/settings/src/main/kotlin/com/divinelink/feature/settings/app/account/jellyseerr/JellyseerrSettingsScreen.kt
@@ -44,7 +44,6 @@ fun SharedTransitionScope.JellyseerrSettingsScreen(
       label = "Jellyseerr State Animated Content",
       contentKey = { state ->
         when (state) {
-          is JellyseerrState.Loading -> "Loading"
           is JellyseerrState.Initial -> "Initial"
           is JellyseerrState.LoggedIn -> "LoggedIn"
         }
@@ -68,9 +67,6 @@ fun SharedTransitionScope.JellyseerrSettingsScreen(
             viewModel.onJellyseerrInteraction(it)
           },
         )
-        JellyseerrState.Loading -> {
-          // Do nothing
-        }
       }
     }
   }

--- a/feature/settings/src/main/kotlin/com/divinelink/feature/settings/app/account/jellyseerr/JellyseerrSettingsUiState.kt
+++ b/feature/settings/src/main/kotlin/com/divinelink/feature/settings/app/account/jellyseerr/JellyseerrSettingsUiState.kt
@@ -10,7 +10,10 @@ data class JellyseerrSettingsUiState(
   companion object {
     fun initial(): JellyseerrSettingsUiState = JellyseerrSettingsUiState(
       snackbarMessage = null,
-      jellyseerrState = JellyseerrState.Loading,
+      jellyseerrState = JellyseerrState.Initial(
+        address = "",
+        isLoading = false,
+      ),
     )
   }
 }

--- a/feature/settings/src/main/kotlin/com/divinelink/feature/settings/app/account/jellyseerr/JellyseerrSettingsViewModel.kt
+++ b/feature/settings/src/main/kotlin/com/divinelink/feature/settings/app/account/jellyseerr/JellyseerrSettingsViewModel.kt
@@ -63,11 +63,11 @@ class JellyseerrSettingsViewModel(
           }
         }.onFailure {
           ErrorHandler.create(it) {
-//            otherwise {
-            _uiState.setSnackbarMessage(
-              UIText.ResourceText(uiR.string.core_ui_error_retry),
-            )
-//            }
+            otherwise {
+              _uiState.setSnackbarMessage(
+                UIText.ResourceText(uiR.string.core_ui_error_retry),
+              )
+            }
           }
         }
       }.launchIn(viewModelScope)
@@ -255,7 +255,6 @@ private fun MutableStateFlow<JellyseerrSettingsUiState>.setJellyseerrLoading(loa
           isLoading = loading,
         ),
       )
-      JellyseerrState.Loading -> uiState
     }
   }
 }

--- a/feature/settings/src/main/kotlin/com/divinelink/feature/settings/app/account/jellyseerr/JellyseerrSettingsViewModel.kt
+++ b/feature/settings/src/main/kotlin/com/divinelink/feature/settings/app/account/jellyseerr/JellyseerrSettingsViewModel.kt
@@ -17,6 +17,7 @@ import com.divinelink.core.ui.snackbar.SnackbarMessage
 import com.divinelink.feature.settings.R
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onCompletion
 import kotlinx.coroutines.flow.onEach
@@ -37,9 +38,20 @@ class JellyseerrSettingsViewModel(
 
   init {
     getJellyseerrDetailsUseCase.invoke(true)
+      .distinctUntilChanged()
       .onEach { result ->
         result.onSuccess {
-          result.data?.let { accountDetails ->
+          val accountDetails = result.data
+          if (accountDetails == null) {
+            _uiState.update {
+              it.copy(
+                jellyseerrState = JellyseerrState.Initial(
+                  address = "",
+                  isLoading = false,
+                ),
+              )
+            }
+          } else {
             _uiState.update {
               it.copy(
                 jellyseerrState = JellyseerrState.LoggedIn(
@@ -48,22 +60,14 @@ class JellyseerrSettingsViewModel(
                 ),
               )
             }
-          } ?: _uiState.update {
-            it.copy(
-              jellyseerrState = JellyseerrState.Initial(
-                address = "",
-                isLoading = false,
-              ),
-            )
           }
         }.onFailure {
-          _uiState.update {
-            it.copy(
-              jellyseerrState = JellyseerrState.Initial(
-                address = "",
-                isLoading = false,
-              ),
+          ErrorHandler.create(it) {
+//            otherwise {
+            _uiState.setSnackbarMessage(
+              UIText.ResourceText(uiR.string.core_ui_error_retry),
             )
+//            }
           }
         }
       }.launchIn(viewModelScope)

--- a/feature/settings/src/test/kotlin/com/divinelink/feature/settings/app/account/jellyseerr/JellyseerrSettingsScreenTest.kt
+++ b/feature/settings/src/test/kotlin/com/divinelink/feature/settings/app/account/jellyseerr/JellyseerrSettingsScreenTest.kt
@@ -76,6 +76,7 @@ class JellyseerrSettingsScreenTest : ComposeTest() {
 
   @Test
   fun `test jellyseerr state is initial when user is not logged in`() = runTest {
+    getJellyseerrDetailsUseCase.mockSuccess(Result.success(null))
     val viewModel = setupViewModel()
 
     setSharedLayoutContent {
@@ -94,6 +95,7 @@ class JellyseerrSettingsScreenTest : ComposeTest() {
   @Test
   fun `test login with jellyfin account`() = runTest {
     loginJellyseerrUseCase.mockSuccess(flowOf(loggedInJellyfin))
+    getJellyseerrDetailsUseCase.mockSuccess(Result.success(null))
 
     val viewModel = setupViewModel()
 
@@ -173,6 +175,7 @@ class JellyseerrSettingsScreenTest : ComposeTest() {
   @Test
   fun `test login with jellyseerr account`() = runTest {
     loginJellyseerrUseCase.mockSuccess(flowOf(loggedInJellyseerr))
+    getJellyseerrDetailsUseCase.mockSuccess(Result.success(null))
 
     val viewModel = setupViewModel()
 
@@ -287,6 +290,7 @@ class JellyseerrSettingsScreenTest : ComposeTest() {
   @Test
   fun `test re-selecting the same login method hides it`() = runTest {
     loginJellyseerrUseCase.mockSuccess(flowOf(loggedInJellyseerr))
+    getJellyseerrDetailsUseCase.mockSuccess(Result.success(null))
 
     val viewModel = setupViewModel()
 
@@ -333,6 +337,7 @@ class JellyseerrSettingsScreenTest : ComposeTest() {
   fun `test credentials for login methods are kept across expanding and collapsing cards`() =
     runTest {
       loginJellyseerrUseCase.mockSuccess(flowOf(loggedInJellyseerr))
+      getJellyseerrDetailsUseCase.mockSuccess(Result.success(null))
 
       val viewModel = setupViewModel()
 

--- a/feature/settings/src/test/kotlin/com/divinelink/feature/settings/app/account/jellyseerr/JellyseerrSettingsViewModelTest.kt
+++ b/feature/settings/src/test/kotlin/com/divinelink/feature/settings/app/account/jellyseerr/JellyseerrSettingsViewModelTest.kt
@@ -3,11 +3,12 @@ package com.divinelink.feature.settings.app.account.jellyseerr
 import com.divinelink.core.commons.exception.InvalidStatusException
 import com.divinelink.core.model.Password
 import com.divinelink.core.model.Username
-import com.divinelink.core.model.jellyseerr.JellyseerrLoginData
 import com.divinelink.core.model.jellyseerr.JellyseerrAuthMethod
+import com.divinelink.core.model.jellyseerr.JellyseerrLoginData
 import com.divinelink.core.model.jellyseerr.JellyseerrState
 import com.divinelink.core.testing.MainDispatcherRule
 import com.divinelink.core.testing.assertUiState
+import com.divinelink.core.testing.expectUiStates
 import com.divinelink.core.testing.factories.model.jellyseerr.JellyseerrAccountDetailsFactory
 import com.divinelink.core.ui.UIText
 import com.divinelink.core.ui.snackbar.SnackbarMessage
@@ -255,7 +256,7 @@ class JellyseerrSettingsViewModelTest {
   }
 
   @Test
-  fun `test getJellyseerrAccount with null clear logged in data`() = runTest {
+  fun `test getJellyseerrAccount with null sets logged in data`() = runTest {
     testRobot
       .mockJellyseerrAccountDetailsResponse(Result.success(null))
       .buildViewModel()
@@ -264,6 +265,52 @@ class JellyseerrSettingsViewModelTest {
           jellyseerrState = JellyseerrState.Initial(
             isLoading = false,
             address = "",
+          ),
+        ),
+      )
+  }
+
+  @Test
+  fun `test login and then logout`() = runTest {
+    testRobot
+      .mockJellyseerrAccountDetailsResponse(Result.success(null))
+      .buildViewModel()
+      .assertUiState(
+        createUiState(
+          jellyseerrState = JellyseerrState.Initial(
+            isLoading = false,
+            address = "",
+          ),
+        ),
+      )
+      .mockLoginJellyseerrResponse(Result.success(JellyseerrAccountDetailsFactory.jellyseerr()))
+      .onSelectedJellyseerrLoginMethod(JellyseerrAuthMethod.JELLYSEERR)
+      .expectUiStates(
+        action = { onLoginJellyseerr() },
+        uiStates = listOf(
+          createUiState(
+            jellyseerrState = JellyseerrState.Initial(
+              address = "",
+              isLoading = false,
+              preferredOption = JellyseerrAuthMethod.JELLYSEERR,
+            ),
+          ),
+          createUiState(
+            jellyseerrState = JellyseerrState.LoggedIn(
+              isLoading = false,
+              accountDetails = JellyseerrAccountDetailsFactory.jellyseerr(),
+            ),
+          ),
+        ),
+      )
+      .mockLogoutJellyseerrResponse(Result.success(""))
+      .onLogoutJellyseerr()
+      .assertUiState(
+        createUiState(
+          jellyseerrState = JellyseerrState.Initial(
+            address = "",
+            isLoading = false,
+            preferredOption = null,
           ),
         ),
       )

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,6 +11,7 @@ android-tools = "31.4.0"
 # android-tools and agp should be updated together
 agp = "8.4.0"
 core-ktx = "1.13.1"
+coil = "3.0.0-alpha08"
 junit = "4.13.2"
 androidx-test-ext-junit = "1.2.1"
 androidx-tracing = "1.3.0-alpha02"
@@ -34,7 +35,7 @@ encrypted-prefs = '1.1.0-alpha04'
 kotlinx-coroutines = '1.9.0'
 
 # Network & Serialization
-ktor = "2.3.8"
+ktor = "2.3.12"
 kotlinx-serialization = "1.7.1"
 
 # Depedency Injection
@@ -102,7 +103,8 @@ compose-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4
 
 compose-shimmer = { group = "com.valentinilk.shimmer", name = "compose-shimmer", version.ref = "compose-shimmer" }
 
-compose-coil = "io.coil-kt.coil3:coil-compose:3.0.0-alpha08"
+coil = { group = "io.coil-kt.coil3", name = "coil-compose", version.ref = "coil" }
+coil-ktor = { group = "io.coil-kt.coil3", name = "coil-network-ktor", version.ref = "coil" }
 
 # Compose Navigation
 compose-destinations-core = { module = "io.github.raamcosta.compose-destinations:core", version.ref = "compose-destinations" }


### PR DESCRIPTION
This pull request introduces a new component: an expandable FAB, similar to the one in Google Calendar. When the FAB is clicked, the background is dimmed, and the main actions are displayed with a staggered animation. Additionally, the FAB is now responsive to the Snackbar, automatically animating above it when the Snackbar is shown.

The primary motivation for this is to make the main actions clearer and to enhance the significance of the Jellyseerr's `Request` action, but it'll also enable us to add more core actions in the future: i.e `Add to list` etc.. 

### Showcase
https://github.com/user-attachments/assets/b6fff6e5-21f2-4772-9def-a5a3ad4c9157